### PR TITLE
[Discussion] Using BufferedStream

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -105,10 +105,14 @@ namespace System.IO.Tests
             using (FileStream fsr = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 fs.Write(TestBuffer, 0, TestBuffer.Length);
-                Assert.Equal(TestBuffer.Length, fs.Length);
 
                 // Make sure that we've actually buffered it, read handle won't see any changes
                 Assert.Equal(0, fsr.Length);
+
+                // previously accessing Length was not causing a Flush of the internal buffer
+                // after using BufferedStream by FileStream iternally, now it does
+                // TODO: verify with the reviewers if such change is OK
+                Assert.Equal(TestBuffer.Length, fs.Length);
 
                 // This should cause a write, after it completes the two handles should be in sync
                 Flush(fs, flushToDisk);

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
@@ -37,10 +37,14 @@ namespace System.IO.Tests
             using (FileStream fsr = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 fs.Write(TestBuffer, 0, TestBuffer.Length);
-                Assert.Equal(TestBuffer.Length, fs.Length);
 
                 // Make sure that we've actually buffered it, read handle won't see any changes
                 Assert.Equal(0, fsr.Length);
+
+                // previously accessing Length was not causing a Flush of the internal buffer
+                // after using BufferedStream by FileStream iternally, now it does
+                // TODO: verify with the reviewers if such change is OK
+                Assert.Equal(TestBuffer.Length, fs.Length);
 
                 // This should cause a write, after it completes the two handles should be in sync
                 await fs.FlushAsync();

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -38,6 +38,19 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void DisposingBufferedStreamThatWrapsAFileStreamWhichHasBennClosedViaSafeFileHandleCloseDoesNotThrow()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                var bufferedStream = new BufferedStream(fs, 100);
+
+                fs.SafeFileHandle.Dispose();
+
+                bufferedStream.Dispose(); // must not throw
+            }
+        }
+
+        [Fact]
         public void AccessFlushesFileClosesHandle()
         {
             string fileName = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -117,14 +117,7 @@ namespace System.IO.Tests
 
                     fs.WriteByte(0);
                     fsr.Position++;
-                    if (useAsync && OperatingSystem.IsWindows()) // Async I/O behaviors differ due to kernel-based implementation on Windows
-                    {
-                        Assert.Throws<IOException>(() => FSAssert.CompletesSynchronously(fs.ReadAsync(new byte[1], 0, 1)));
-                    }
-                    else
-                    {
-                        await Assert.ThrowsAsync<IOException>(() => fs.ReadAsync(new byte[1], 0, 1));
-                    }
+                    await Assert.ThrowsAsync<IOException>(() => fs.ReadAsync(new byte[1], 0, 1));
 
                     fs.WriteByte(0);
                     fsr.Position++;

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -220,7 +220,7 @@ namespace System.IO.Tests
                 {
                     writes[i] = WriteAsync(fs, expectedData, i * writeSize, writeSize, cancellationToken);
                     Assert.Null(writes[i].Exception);
-                    if (useAsync)
+                    if (useAsync && writes[i].IsCompletedSuccessfully) // TODO: breaking change, verify with reviewers
                     {
                         Assert.Equal((i + 1) * writeSize, fs.Position);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -388,6 +388,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BufferedStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\BufferedFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DerivedFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DirectoryNotFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EncodingCache.cs" />
@@ -1623,6 +1624,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\AsyncWindowsFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DisableMediaInsertionPrompt.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DriveInfoInternal.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamHelpers.Windows.cs" />
@@ -1630,6 +1632,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\SyncWindowsFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\WindowsFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Loader\LibraryNameVariation.Windows.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs
@@ -1,0 +1,654 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.CompilerServices;
+
+/*
+ * Win32FileStream supports different modes of accessing the disk - async mode
+ * and sync mode.  They are two completely different codepaths in the
+ * sync & async methods (i.e. Read/Write vs. ReadAsync/WriteAsync).  File
+ * handles in NT can be opened in only sync or overlapped (async) mode,
+ * and we have to deal with this pain.  Stream has implementations of
+ * the sync methods in terms of the async ones, so we'll
+ * call through to our base class to get those methods when necessary.
+ *
+ * Also buffering is added into Win32FileStream as well. Folded in the
+ * code from BufferedStream, so all the comments about it being mostly
+ * aggressive (and the possible perf improvement) apply to Win32FileStream as
+ * well.  Also added some buffering to the async code paths.
+ *
+ * Class Invariants:
+ * The class has one buffer, shared for reading & writing.  It can only be
+ * used for one or the other at any point in time - not both.  The following
+ * should be true:
+ *   0 <= _readPos <= _readLen < _bufferSize
+ *   0 <= _writePos < _bufferSize
+ *   _readPos == _readLen && _readPos > 0 implies the read buffer is valid,
+ *     but we're at the end of the buffer.
+ *   _readPos == _readLen == 0 means the read buffer contains garbage.
+ *   Either _writePos can be greater than 0, or _readLen & _readPos can be
+ *     greater than zero, but neither can be greater than zero at the same time.
+ *
+ */
+
+namespace System.IO
+{
+    internal sealed partial class AsyncWindowsFileStreamStrategy : WindowsFileStreamStrategy
+    {
+        private static readonly unsafe IOCompletionCallback s_ioCallback = FileStreamCompletionSource.IOCallback;
+
+        private PreAllocatedOverlapped? _preallocatedOverlapped;     // optimization for async ops to avoid per-op allocations
+        private FileStreamCompletionSource? _currentOverlappedOwner; // async op currently using the preallocated overlapped
+
+        internal AsyncWindowsFileStreamStrategy(SafeFileHandle handle, FileAccess access)
+            : base(handle, access)
+        {
+        }
+
+        internal AsyncWindowsFileStreamStrategy(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)
+            : base(path, mode, access, share, options)
+        {
+        }
+
+        internal override bool IsAsync => true;
+
+        public override ValueTask DisposeAsync()
+        {
+            // the order matters, let the base class Dispose handle first
+            ValueTask result = base.DisposeAsync();
+            Debug.Assert(result.IsCompleted, "the method must be sync, as it performs no flushing");
+
+            _preallocatedOverlapped?.Dispose();
+
+            return result;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // the order matters, let the base class Dispose handle first
+            base.Dispose(disposing);
+
+            _preallocatedOverlapped?.Dispose();
+        }
+
+        protected override void OnInitFromHandle(SafeFileHandle handle)
+        {
+            // This is necessary for async IO using IO Completion ports via our
+            // managed Threadpool API's.  This calls the OS's
+            // BindIoCompletionCallback method, and passes in a stub for the
+            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
+            // struct for this request and gets a delegate to a managed callback
+            // from there, which it then calls on a threadpool thread.  (We allocate
+            // our native OVERLAPPED structs 2 pointers too large and store EE
+            // state & a handle to a delegate there.)
+            //
+            // If, however, we've already bound this file handle to our completion port,
+            // don't try to bind it again because it will fail.  A handle can only be
+            // bound to a single completion port at a time.
+            if (!(handle.IsAsync ?? false))
+            {
+                try
+                {
+                    handle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(handle);
+                }
+                catch (Exception ex)
+                {
+                    // If you passed in a synchronous handle and told us to use
+                    // it asynchronously, throw here.
+                    throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle), ex);
+                }
+            }
+        }
+
+        protected override void OnInit()
+        {
+            // This is necessary for async IO using IO Completion ports via our
+            // managed Threadpool API's.  This (theoretically) calls the OS's
+            // BindIoCompletionCallback method, and passes in a stub for the
+            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
+            // struct for this request and gets a delegate to a managed callback
+            // from there, which it then calls on a threadpool thread.  (We allocate
+            // our native OVERLAPPED structs 2 pointers too large and store EE state
+            // & GC handles there, one to an IAsyncResult, the other to a delegate.)
+            try
+            {
+                _fileHandle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(_fileHandle);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new IOException(SR.IO_BindHandleFailed, ex);
+            }
+            finally
+            {
+                if (_fileHandle.ThreadPoolBinding == null)
+                {
+                    // We should close the handle so that the handle is not open until SafeFileHandle GC
+                    Debug.Assert(!_exposedHandle, "Are we closing handle that we exposed/not own, how?");
+                    _fileHandle.Dispose();
+                }
+            }
+        }
+
+        // called by BufferedStream. TODO: find a cleaner solution
+        internal void OnBufferAllocated(byte[] buffer)
+        {
+            Debug.Assert(buffer != null);
+            Debug.Assert(_preallocatedOverlapped == null);
+
+            _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, buffer);
+            _buffer = buffer;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadAsyncInternal(new Memory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+            => new ValueTask<int>(ReadAsyncInternal(destination, cancellationToken));
+
+        private unsafe Task<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken = default)
+        {
+            Debug.Assert(CanRead, "BufferedStream has already verified that");
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+
+            // Create and store async stream class library specific data in the async result
+            FileStreamCompletionSource completionSource = FileStreamCompletionSource.Create(this, 0, destination);
+            NativeOverlapped* intOverlapped = completionSource.Overlapped;
+
+            // Calculate position in the file we should be at after the read is done
+            if (CanSeek)
+            {
+                long len = Length;
+
+                // Make sure we are reading from the position that we think we are
+                VerifyOSHandlePosition();
+
+                if (_filePosition + destination.Length > len)
+                {
+                    if (_filePosition <= len)
+                    {
+                        destination = destination.Slice(0, (int)(len - _filePosition));
+                    }
+                    else
+                    {
+                        destination = default;
+                    }
+                }
+
+                // Now set the position to read from in the NativeOverlapped struct
+                // For pipes, we should leave the offset fields set to 0.
+                intOverlapped->OffsetLow = unchecked((int)_filePosition);
+                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
+
+                // When using overlapped IO, the OS is not supposed to
+                // touch the file pointer location at all.  We will adjust it
+                // ourselves. This isn't threadsafe.
+
+                // WriteFile should not update the file pointer when writing
+                // in overlapped mode, according to MSDN.  But it does update
+                // the file pointer when writing to a UNC path!
+                // So changed the code below to seek to an absolute
+                // location, not a relative one.  ReadFile seems consistent though.
+                SeekCore(_fileHandle, destination.Length, SeekOrigin.Current);
+            }
+
+            // queue an async ReadFile operation and pass in a packed overlapped
+            int r = ReadFileNative(_fileHandle, destination.Span, intOverlapped, out int errorCode);
+
+            // ReadFile, the OS version, will return 0 on failure.  But
+            // my ReadFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
+            // on async requests that completed sequentially, r==0
+            // You will NEVER RELIABLY be able to get the number of bytes
+            // read back from this call when using overlapped structures!  You must
+            // not pass in a non-null lpNumBytesRead to ReadFile when using
+            // overlapped structures!  This is by design NT behavior.
+            if (r == -1)
+            {
+                // For pipes, when they hit EOF, they will come here.
+                if (errorCode == ERROR_BROKEN_PIPE)
+                {
+                    // Not an error, but EOF.  AsyncFSCallback will NOT be
+                    // called.  Call the user callback here.
+
+                    // We clear the overlapped status bit for this special case.
+                    // Failure to do so looks like we are freeing a pending overlapped later.
+                    intOverlapped->InternalLow = IntPtr.Zero;
+                    completionSource.SetCompletedSynchronously(0);
+                }
+                else if (errorCode != ERROR_IO_PENDING)
+                {
+                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    {
+                        SeekCore(_fileHandle, 0, SeekOrigin.Current);
+                    }
+
+                    completionSource.ReleaseNativeResource();
+
+                    if (errorCode == ERROR_HANDLE_EOF)
+                    {
+                        throw Error.GetEndOfFile();
+                    }
+                    else
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                    }
+                }
+                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
+                {
+                    // Only once the IO is pending do we register for cancellation
+                    completionSource.RegisterForCancellation(cancellationToken);
+                }
+            }
+            else
+            {
+                // Due to a workaround for a race condition in NT's ReadFile &
+                // WriteFile routines, we will always be returning 0 from ReadFileNative
+                // when we do async IO instead of the number of bytes read,
+                // irregardless of whether the operation completed
+                // synchronously or asynchronously.  We absolutely must not
+                // set asyncResult._numBytes here, since will never have correct
+                // results.
+            }
+
+            return completionSource.Task;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => WriteAsyncInternal(buffer, cancellationToken);
+
+        // Instance method to help code external to this MarshalByRefObject avoid
+        // accessing its fields by ref.  This avoids a compiler warning.
+        private FileStreamCompletionSource? CompareExchangeCurrentOverlappedOwner(FileStreamCompletionSource? newSource, FileStreamCompletionSource? existingSource) =>
+            Interlocked.CompareExchange(ref _currentOverlappedOwner, newSource, existingSource);
+
+        private ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+            => new ValueTask(WriteAsyncInternalCore(source, cancellationToken));
+
+        private unsafe Task WriteAsyncInternalCore(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            Debug.Assert(CanWrite, "BufferedStream has already verified that");
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+
+            // Create and store async stream class library specific data in the async result
+            FileStreamCompletionSource completionSource = FileStreamCompletionSource.Create(this, 0, source);
+            NativeOverlapped* intOverlapped = completionSource.Overlapped;
+
+            if (CanSeek)
+            {
+                // Make sure we set the length of the file appropriately.
+                long len = Length;
+
+                // Make sure we are writing to the position that we think we are
+                VerifyOSHandlePosition();
+
+                if (_filePosition + source.Length > len)
+                {
+                    SetLengthCore(_filePosition + source.Length);
+                }
+
+                // Now set the position to read from in the NativeOverlapped struct
+                // For pipes, we should leave the offset fields set to 0.
+                intOverlapped->OffsetLow = (int)_filePosition;
+                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
+
+                // When using overlapped IO, the OS is not supposed to
+                // touch the file pointer location at all.  We will adjust it
+                // ourselves.  This isn't threadsafe.
+                SeekCore(_fileHandle, source.Length, SeekOrigin.Current);
+            }
+
+            // queue an async WriteFile operation and pass in a packed overlapped
+            int r = WriteFileNative(_fileHandle, source.Span, intOverlapped, out int errorCode);
+
+            // WriteFile, the OS version, will return 0 on failure.  But
+            // my WriteFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
+            // On async requests that completed sequentially, r==0
+            // You will NEVER RELIABLY be able to get the number of bytes
+            // written back from this call when using overlapped IO!  You must
+            // not pass in a non-null lpNumBytesWritten to WriteFile when using
+            // overlapped structures!  This is ByDesign NT behavior.
+            if (r == -1)
+            {
+                // For pipes, when they are closed on the other side, they will come here.
+                if (errorCode == ERROR_NO_DATA)
+                {
+                    // Not an error, but EOF. AsyncFSCallback will NOT be called.
+                    // Completing TCS and return cached task allowing the GC to collect TCS.
+                    completionSource.SetCompletedSynchronously(0);
+                    return Task.CompletedTask;
+                }
+                else if (errorCode != ERROR_IO_PENDING)
+                {
+                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    {
+                        SeekCore(_fileHandle, 0, SeekOrigin.Current);
+                    }
+
+                    completionSource.ReleaseNativeResource();
+
+                    if (errorCode == ERROR_HANDLE_EOF)
+                    {
+                        throw Error.GetEndOfFile();
+                    }
+                    else
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                    }
+                }
+                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
+                {
+                    // Only once the IO is pending do we register for cancellation
+                    completionSource.RegisterForCancellation(cancellationToken);
+                }
+            }
+            else
+            {
+                // Due to a workaround for a race condition in NT's ReadFile &
+                // WriteFile routines, we will always be returning 0 from WriteFileNative
+                // when we do async IO instead of the number of bytes written,
+                // irregardless of whether the operation completed
+                // synchronously or asynchronously.  We absolutely must not
+                // set asyncResult._numBytes here, since will never have correct
+                // results.
+            }
+
+            return completionSource.Task;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            ValidateCopyToArguments(destination, bufferSize);
+
+            // Fail if the file was closed
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+            if (!CanRead)
+            {
+                throw Error.GetReadNotSupported();
+            }
+
+            // Bail early for cancellation if cancellation has been requested
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            return AsyncModeCopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        private async Task AsyncModeCopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+            Debug.Assert(CanRead, "_parent.CanRead");
+
+            // For efficiency, we avoid creating a new task and associated state for each asynchronous read.
+            // Instead, we create a single reusable awaitable object that will be triggered when an await completes
+            // and reset before going again.
+            var readAwaitable = new AsyncCopyToAwaitable(this);
+
+            // Make sure we are reading from the position that we think we are.
+            // Only set the position in the awaitable if we can seek (e.g. not for pipes).
+            bool canSeek = CanSeek;
+            if (canSeek)
+            {
+                VerifyOSHandlePosition();
+                readAwaitable._position = _filePosition;
+            }
+
+            // Get the buffer to use for the copy operation, as the base CopyToAsync does. We don't try to use
+            // _buffer here, even if it's not null, as concurrent operations are allowed, and another operation may
+            // actually be using the buffer already. Plus, it'll be rare for _buffer to be non-null, as typically
+            // CopyToAsync is used as the only operation performed on the stream, and the buffer is lazily initialized.
+            // Further, typically the CopyToAsync buffer size will be larger than that used by the FileStream, such that
+            // we'd likely be unable to use it anyway.  Instead, we rent the buffer from a pool.
+            byte[] copyBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+
+            // Allocate an Overlapped we can use repeatedly for all operations
+            var awaitableOverlapped = new PreAllocatedOverlapped(AsyncCopyToAwaitable.s_callback, readAwaitable, copyBuffer);
+            var cancellationReg = default(CancellationTokenRegistration);
+            try
+            {
+                // Register for cancellation.  We do this once for the whole copy operation, and just try to cancel
+                // whatever read operation may currently be in progress, if there is one.  It's possible the cancellation
+                // request could come in between operations, in which case we flag that with explicit calls to ThrowIfCancellationRequested
+                // in the read/write copy loop.
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationReg = cancellationToken.UnsafeRegister(static s =>
+                    {
+                        Debug.Assert(s is AsyncCopyToAwaitable);
+                        var innerAwaitable = (AsyncCopyToAwaitable)s;
+                        unsafe
+                        {
+                            lock (innerAwaitable.CancellationLock) // synchronize with cleanup of the overlapped
+                            {
+                                if (innerAwaitable._nativeOverlapped != null)
+                                {
+                                    // Try to cancel the I/O.  We ignore the return value, as cancellation is opportunistic and we
+                                    // don't want to fail the operation because we couldn't cancel it.
+                                    Interop.Kernel32.CancelIoEx(innerAwaitable._fileStream._fileHandle, innerAwaitable._nativeOverlapped);
+                                }
+                            }
+                        }
+                    }, readAwaitable);
+                }
+
+                // Repeatedly read from this FileStream and write the results to the destination stream.
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    readAwaitable.ResetForNextOperation();
+
+                    try
+                    {
+                        bool synchronousSuccess;
+                        int errorCode;
+                        unsafe
+                        {
+                            // Allocate a native overlapped for our reusable overlapped, and set position to read based on the next
+                            // desired address stored in the awaitable.  (This position may be 0, if either we're at the beginning or
+                            // if the stream isn't seekable.)
+                            readAwaitable._nativeOverlapped = _fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(awaitableOverlapped);
+                            if (canSeek)
+                            {
+                                readAwaitable._nativeOverlapped->OffsetLow = unchecked((int)readAwaitable._position);
+                                readAwaitable._nativeOverlapped->OffsetHigh = (int)(readAwaitable._position >> 32);
+                            }
+
+                            // Kick off the read.
+                            synchronousSuccess = ReadFileNative(_fileHandle, copyBuffer, readAwaitable._nativeOverlapped, out errorCode) >= 0;
+                        }
+
+                        // If the operation did not synchronously succeed, it either failed or initiated the asynchronous operation.
+                        if (!synchronousSuccess)
+                        {
+                            switch (errorCode)
+                            {
+                                case ERROR_IO_PENDING:
+                                    // Async operation in progress.
+                                    break;
+                                case ERROR_BROKEN_PIPE:
+                                case ERROR_HANDLE_EOF:
+                                    // We're at or past the end of the file, and the overlapped callback
+                                    // won't be raised in these cases. Mark it as completed so that the await
+                                    // below will see it as such.
+                                    readAwaitable.MarkCompleted();
+                                    break;
+                                default:
+                                    // Everything else is an error (and there won't be a callback).
+                                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                            }
+                        }
+
+                        // Wait for the async operation (which may or may not have already completed), then throw if it failed.
+                        await readAwaitable;
+                        switch (readAwaitable._errorCode)
+                        {
+                            case 0: // success
+                                break;
+                            case ERROR_BROKEN_PIPE: // logically success with 0 bytes read (write end of pipe closed)
+                            case ERROR_HANDLE_EOF:  // logically success with 0 bytes read (read at end of file)
+                                Debug.Assert(readAwaitable._numBytes == 0, $"Expected 0 bytes read, got {readAwaitable._numBytes}");
+                                break;
+                            case Interop.Errors.ERROR_OPERATION_ABORTED: // canceled
+                                throw new OperationCanceledException(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                            default: // error
+                                throw Win32Marshal.GetExceptionForWin32Error((int)readAwaitable._errorCode, _path);
+                        }
+
+                        // Successful operation.  If we got zero bytes, we're done: exit the read/write loop.
+                        int numBytesRead = (int)readAwaitable._numBytes;
+                        if (numBytesRead == 0)
+                        {
+                            break;
+                        }
+
+                        // Otherwise, update the read position for next time accordingly.
+                        if (canSeek)
+                        {
+                            readAwaitable._position += numBytesRead;
+                        }
+                    }
+                    finally
+                    {
+                        // Free the resources for this read operation
+                        unsafe
+                        {
+                            NativeOverlapped* overlapped;
+                            lock (readAwaitable.CancellationLock) // just an Exchange, but we need this to be synchronized with cancellation, so using the same lock
+                            {
+                                overlapped = readAwaitable._nativeOverlapped;
+                                readAwaitable._nativeOverlapped = null;
+                            }
+                            if (overlapped != null)
+                            {
+                                _fileHandle.ThreadPoolBinding!.FreeNativeOverlapped(overlapped);
+                            }
+                        }
+                    }
+
+                    // Write out the read data.
+                    await destination.WriteAsync(new ReadOnlyMemory<byte>(copyBuffer, 0, (int)readAwaitable._numBytes), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Cleanup from the whole copy operation
+                cancellationReg.Dispose();
+                awaitableOverlapped.Dispose();
+
+                ArrayPool<byte>.Shared.Return(copyBuffer);
+
+                // Make sure the stream's current position reflects where we ended up
+                if (!_fileHandle.IsClosed && CanSeek)
+                {
+                    SeekCore(_fileHandle, 0, SeekOrigin.End);
+                }
+            }
+        }
+
+        /// <summary>Used by CopyToAsync to enable awaiting the result of an overlapped I/O operation with minimal overhead.</summary>
+        private sealed unsafe class AsyncCopyToAwaitable : ICriticalNotifyCompletion
+        {
+            /// <summary>Sentinel object used to indicate that the I/O operation has completed before being awaited.</summary>
+            private static readonly Action s_sentinel = () => { };
+            /// <summary>Cached delegate to IOCallback.</summary>
+            internal static readonly IOCompletionCallback s_callback = IOCallback;
+
+            /// <summary>The FileStream that owns this instance.</summary>
+            internal readonly AsyncWindowsFileStreamStrategy _fileStream;
+
+            /// <summary>Tracked position representing the next location from which to read.</summary>
+            internal long _position;
+            /// <summary>The current native overlapped pointer.  This changes for each operation.</summary>
+            internal NativeOverlapped* _nativeOverlapped;
+            /// <summary>
+            /// null if the operation is still in progress,
+            /// s_sentinel if the I/O operation completed before the await,
+            /// s_callback if it completed after the await yielded.
+            /// </summary>
+            internal Action? _continuation;
+            /// <summary>Last error code from completed operation.</summary>
+            internal uint _errorCode;
+            /// <summary>Last number of read bytes from completed operation.</summary>
+            internal uint _numBytes;
+
+            /// <summary>Lock object used to protect cancellation-related access to _nativeOverlapped.</summary>
+            internal object CancellationLock => this;
+
+            /// <summary>Initialize the awaitable.</summary>
+            internal AsyncCopyToAwaitable(AsyncWindowsFileStreamStrategy fileStream)
+            {
+                _fileStream = fileStream;
+            }
+
+            /// <summary>Reset state to prepare for the next read operation.</summary>
+            internal void ResetForNextOperation()
+            {
+                Debug.Assert(_position >= 0, $"Expected non-negative position, got {_position}");
+                _continuation = null;
+                _errorCode = 0;
+                _numBytes = 0;
+            }
+
+            /// <summary>Overlapped callback: store the results, then invoke the continuation delegate.</summary>
+            internal static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOVERLAP)
+            {
+                var awaitable = (AsyncCopyToAwaitable?)ThreadPoolBoundHandle.GetNativeOverlappedState(pOVERLAP);
+                Debug.Assert(awaitable != null);
+
+                Debug.Assert(!ReferenceEquals(awaitable._continuation, s_sentinel), "Sentinel must not have already been set as the continuation");
+                awaitable._errorCode = errorCode;
+                awaitable._numBytes = numBytes;
+
+                (awaitable._continuation ?? Interlocked.CompareExchange(ref awaitable._continuation, s_sentinel, null))?.Invoke();
+            }
+
+            /// <summary>
+            /// Called when it's known that the I/O callback for an operation will not be invoked but we'll
+            /// still be awaiting the awaitable.
+            /// </summary>
+            internal void MarkCompleted()
+            {
+                Debug.Assert(_continuation == null, "Expected null continuation");
+                _continuation = s_sentinel;
+            }
+
+            public AsyncCopyToAwaitable GetAwaiter() => this;
+            public bool IsCompleted => ReferenceEquals(_continuation, s_sentinel);
+            public void GetResult() { }
+            public void OnCompleted(Action continuation) => UnsafeOnCompleted(continuation);
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (ReferenceEquals(_continuation, s_sentinel) ||
+                    Interlocked.CompareExchange(ref _continuation, continuation, null) != null)
+                {
+                    Debug.Assert(ReferenceEquals(_continuation, s_sentinel), $"Expected continuation set to s_sentinel, got ${_continuation}");
+                    Task.Run(continuation);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -17,24 +16,6 @@ using System.Runtime.CompilerServices;
  * and we have to deal with this pain.  Stream has implementations of
  * the sync methods in terms of the async ones, so we'll
  * call through to our base class to get those methods when necessary.
- *
- * Also buffering is added into Win32FileStream as well. Folded in the
- * code from BufferedStream, so all the comments about it being mostly
- * aggressive (and the possible perf improvement) apply to Win32FileStream as
- * well.  Also added some buffering to the async code paths.
- *
- * Class Invariants:
- * The class has one buffer, shared for reading & writing.  It can only be
- * used for one or the other at any point in time - not both.  The following
- * should be true:
- *   0 <= _readPos <= _readLen < _bufferSize
- *   0 <= _writePos < _bufferSize
- *   _readPos == _readLen && _readPos > 0 implies the read buffer is valid,
- *     but we're at the end of the buffer.
- *   _readPos == _readLen == 0 means the read buffer contains garbage.
- *   Either _writePos can be greater than 0, or _readLen & _readPos can be
- *     greater than zero, but neither can be greater than zero at the same time.
- *
  */
 
 namespace System.IO

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedFileStreamStrategy.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.IO
+{
+    // this type exists so we can avoid duplicating the buffering logic in every FileStreamStrategy implementation
+    // for simple properties that would just call the wrapped stream properties, we call strategy directly
+    // for everything else, we are calling BufferedStream methods that take care of all the buffering work
+    internal sealed class BufferedFileStreamStrategy : FileStreamStrategy
+    {
+        private readonly FileStreamStrategy _strategy;
+        private readonly BufferedStream _bufferedStream;
+        private readonly FileStream _fileStream;
+
+        internal BufferedFileStreamStrategy(FileStream fileStream, FileStreamStrategy strategy, int bufferSize)
+        {
+            _fileStream = fileStream;
+            _strategy = strategy;
+            _bufferedStream = new BufferedStream(strategy, bufferSize, allowForZeroByteReads: true);
+        }
+
+        ~BufferedFileStreamStrategy()
+        {
+            // Preserved for compatibility since FileStream has defined a
+            // finalizer in past releases and derived classes may depend
+            // on Dispose(false) call.
+            _fileStream.DisposeInternal(false);
+        }
+
+        public override bool CanRead => _strategy.CanRead;
+
+        public override bool CanWrite => _strategy.CanWrite;
+
+        public override bool CanSeek => _strategy.CanSeek;
+
+        public override long Length => _bufferedStream.Length;
+
+        public override long Position
+        {
+            get => _bufferedStream.Position;
+            set => _bufferedStream.Position = value;
+        }
+
+        internal override bool IsAsync => _strategy.IsAsync;
+
+        internal override string Name => _strategy.Name;
+
+        internal override SafeFileHandle SafeFileHandle
+        {
+            get
+            {
+                _fileStream.Flush();
+                return _strategy.SafeFileHandle;
+            }
+        }
+
+        internal override bool IsClosed => _strategy.IsClosed;
+
+        internal override void Lock(long position, long length) => _strategy.Lock(position, length);
+
+        internal override void Unlock(long position, long length) => _strategy.Unlock(position, length);
+
+        public override long Seek(long offset, SeekOrigin origin) => _bufferedStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => _bufferedStream.SetLength(value);
+
+        public override int ReadByte() => _bufferedStream.ReadByte();
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+            => _bufferedStream.BeginRead(buffer, offset, count, callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult)
+            => _bufferedStream.EndRead(asyncResult);
+
+        public override int Read(byte[] buffer, int offset, int count) => _bufferedStream.Read(buffer, offset, count);
+
+        public override int Read(Span<byte> buffer) => _bufferedStream.Read(buffer);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _bufferedStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _bufferedStream.ReadAsync(buffer, cancellationToken);
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+            => _bufferedStream.BeginWrite(buffer, offset, count, callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult)
+            => _bufferedStream.EndWrite(asyncResult);
+
+        public override void WriteByte(byte value) => _bufferedStream.WriteByte(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => _bufferedStream.Write(buffer, offset, count);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => _bufferedStream.Write(buffer);
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _bufferedStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => _bufferedStream.WriteAsync(buffer, cancellationToken);
+
+        public override void Flush() => _bufferedStream.Flush();
+
+        internal override void Flush(bool flushToDisk) => _bufferedStream.Flush(flushToDisk);
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // don't try to Flush if the buffer was not used
+            // added to keep *NothingToFlush_CompletesSynchronously tests green
+            if (_bufferedStream.HasSomeDataInTheBuffer)
+            {
+                return _bufferedStream.FlushAsync(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            => _bufferedStream.CopyToAsync(destination, bufferSize, cancellationToken);
+
+        public override ValueTask DisposeAsync()
+        {
+            if (_bufferedStream.HasSomeDataInTheBuffer)
+            {
+                return _bufferedStream.DisposeAsync();
+            }
+            return _strategy.DisposeAsync();
+        }
+
+        internal override void DisposeInternal(bool disposing)
+        {
+            try
+            {
+                // the finalizer must at least try to flush the write buffer
+                // so we enforce it by passing always true
+                _bufferedStream.DisposeInternal(true);
+            }
+            catch (Exception e) when (!disposing && IsIoRelatedException(e))
+            {
+                // On finalization, ignore failures from trying to flush the write buffer,
+                // e.g. if this stream is wrapping a pipe and the pipe is now broken.
+            }
+
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        private static bool IsIoRelatedException(Exception e) =>
+            // These all derive from IOException
+            //     DirectoryNotFoundException
+            //     DriveNotFoundException
+            //     EndOfStreamException
+            //     FileLoadException
+            //     FileNotFoundException
+            //     PathTooLongException
+            //     PipeException
+            e is IOException ||
+            // Note that SecurityException is only thrown on runtimes that support CAS
+            // e is SecurityException ||
+            e is UnauthorizedAccessException ||
+            e is NotSupportedException ||
+            (e is ArgumentException && !(e is ArgumentNullException));
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -51,6 +52,7 @@ namespace System.IO
         private Stream? _stream;                            // Underlying stream.  Close sets _stream to null.
         private byte[]? _buffer;                            // Shared read/write buffer.  Alloc on first use.
         private readonly int _bufferSize;                   // Length of internal buffer (not counting the shadow buffer).
+        private readonly bool _allowForZeroByteReads;
         private int _readPos;                               // Read pointer within shared buffer.
         private int _readLen;                               // Number of bytes read in buffer from _stream.
         private int _writePos;                              // Write pointer within shared buffer.
@@ -82,10 +84,17 @@ namespace System.IO
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
         }
 
+        internal BufferedStream(Stream stream, int bufferSize, bool allowForZeroByteReads) : this(stream, bufferSize)
+        {
+            _allowForZeroByteReads = allowForZeroByteReads;
+        }
+
         private void EnsureNotClosed()
         {
             if (_stream == null)
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+                Throw();
+
+            static void Throw() => throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
         }
 
         private void EnsureCanSeek()
@@ -93,7 +102,9 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanSeek)
-                throw new NotSupportedException(SR.NotSupported_UnseekableStream);
+                Throw();
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
         }
 
         private void EnsureCanRead()
@@ -101,7 +112,9 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanRead)
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+                Throw();
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnreadableStream);
         }
 
         private void EnsureCanWrite()
@@ -109,7 +122,9 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanWrite)
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+                Throw();
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
         }
 
         private void EnsureShadowBufferAllocated()
@@ -127,13 +142,24 @@ namespace System.IO
             _buffer = shadowBuffer;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void EnsureBufferAllocated()
         {
             Debug.Assert(_bufferSize > 0);
 
             // BufferedStream is not intended for multi-threaded use, so no worries about the get/set race on _buffer.
             if (_buffer == null)
+            {
                 _buffer = new byte[_bufferSize];
+
+#if TARGET_WINDOWS
+                // it's quite ugly, but I currently don't have a better idea
+                if (_stream is AsyncWindowsFileStreamStrategy asyncWindowsFileStreamStrategy)
+                {
+                    asyncWindowsFileStreamStrategy.OnBufferAllocated(_buffer);
+                }
+#endif
+            }
         }
 
         public Stream UnderlyingStream
@@ -184,7 +210,7 @@ namespace System.IO
                 EnsureNotClosed();
 
                 if (_writePos > 0)
-                    FlushWrite();
+                    FlushWrite(true);
 
                 return _stream!.Length;
             }
@@ -209,13 +235,17 @@ namespace System.IO
                 EnsureCanSeek();
 
                 if (_writePos > 0)
-                    FlushWrite();
+                    FlushWrite(true);
 
                 _readPos = 0;
                 _readLen = 0;
                 _stream!.Seek(value, SeekOrigin.Begin);
             }
         }
+
+        internal bool HasSomeDataInTheBuffer => _buffer != null && (_writePos > 0 || _readPos < _readLen);
+
+        internal void DisposeInternal(bool disposing) => Dispose(disposing);
 
         protected override void Dispose(bool disposing)
         {
@@ -247,7 +277,8 @@ namespace System.IO
         {
             try
             {
-                if (_stream != null)
+                Stream? stream = _stream;
+                if (stream != null)
                 {
                     try
                     {
@@ -255,7 +286,7 @@ namespace System.IO
                     }
                     finally
                     {
-                        await _stream.DisposeAsync().ConfigureAwait(false);
+                        await stream.DisposeAsync().ConfigureAwait(false);
                     }
                 }
             }
@@ -266,16 +297,24 @@ namespace System.IO
             }
         }
 
-        public override void Flush()
+        public override void Flush() => Flush(true);
+
+        internal void Flush(bool performActualFlush)
         {
             EnsureNotClosed();
 
             // Has write data in the buffer:
             if (_writePos > 0)
             {
-                FlushWrite();
-                Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
-                return;
+                // EnsureNotClosed does not guarantee that the Stream has not been closed
+                // an example could be a call to fileStream.SafeFileHandle.Dispose()
+                // so to avoid getting exception here, we just ensure that we can Write before doing it
+                if (_stream!.CanWrite)
+                {
+                    FlushWrite(performActualFlush);
+                    Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
+                    return;
+                }
             }
 
             // Has read data in the buffer:
@@ -292,7 +331,7 @@ namespace System.IO
                 // User streams may have opted to throw from Flush if CanWrite is false (although the abstract Stream does not do so).
                 // However, if we do not forward the Flush to the underlying stream, we may have problems when chaining several streams.
                 // Let us make a best effort attempt:
-                if (_stream.CanWrite)
+                if (performActualFlush && _stream.CanWrite)
                     _stream.Flush();
 
                 // If the Stream was seekable, then we should have called FlushRead which resets _readPos & _readLen.
@@ -301,7 +340,7 @@ namespace System.IO
             }
 
             // We had no data in the buffer, but we still need to tell the underlying stream to flush.
-            if (_stream!.CanWrite)
+            if (performActualFlush && _stream!.CanWrite)
                 _stream.Flush();
 
             _writePos = _readPos = _readLen = 0;
@@ -384,6 +423,7 @@ namespace System.IO
         /// <summary>
         /// Called by Write methods to clear the Read Buffer
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ClearReadBufferBeforeWrite()
         {
             Debug.Assert(_stream != null);
@@ -403,12 +443,14 @@ namespace System.IO
             // However, since the user did not call a method that is intuitively expected to seek, a better message is in order.
             // Ideally, we would throw an InvalidOperation here, but for backward compat we have to stick with NotSupported.
             if (!_stream.CanSeek)
-                throw new NotSupportedException(SR.NotSupported_CannotWriteToBufferedStreamIfReadBufferCannotBeFlushed);
+                Throw();
 
             FlushRead();
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_CannotWriteToBufferedStreamIfReadBufferCannotBeFlushed);
         }
 
-        private void FlushWrite()
+        private void FlushWrite(bool performActualFlush)
         {
             Debug.Assert(_stream != null);
             Debug.Assert(_readPos == 0 && _readLen == 0,
@@ -418,7 +460,11 @@ namespace System.IO
 
             _stream.Write(_buffer, 0, _writePos);
             _writePos = 0;
-            _stream.Flush();
+
+            if (performActualFlush)
+            {
+                _stream.Flush();
+            }
         }
 
         private async ValueTask FlushWriteAsync(CancellationToken cancellationToken)
@@ -434,6 +480,7 @@ namespace System.IO
             await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int ReadFromBuffer(byte[] buffer, int offset, int count)
         {
             int readbytes = _readLen - _readPos;
@@ -493,7 +540,7 @@ namespace System.IO
             // BUT - this is a breaking change.
             // So: If we could not read all bytes the user asked for from the buffer, we will try once from the underlying
             // stream thus ensuring the same blocking behaviour as if the underlying stream was not wrapped in this BufferedStream.
-            if (bytesFromBuffer == count)
+            if (bytesFromBuffer == count && (count > 0 || !_allowForZeroByteReads))
                 return bytesFromBuffer;
 
             int alreadySatisfied = bytesFromBuffer;
@@ -509,7 +556,7 @@ namespace System.IO
 
             // If there was anything in the write buffer, clear it.
             if (_writePos > 0)
-                FlushWrite();
+                FlushWrite(true);
 
             // If the requested read is larger than buffer size, avoid the buffer and still use a single read:
             if (count >= _bufferSize)
@@ -519,7 +566,7 @@ namespace System.IO
 
             // Ok. We can fill the buffer:
             EnsureBufferAllocated();
-            _readLen = _stream.Read(_buffer!, 0, _bufferSize);
+            _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
 
             bytesFromBuffer = ReadFromBuffer(buffer, offset, count);
 
@@ -541,7 +588,7 @@ namespace System.IO
 
             // Try to read from the buffer.
             int bytesFromBuffer = ReadFromBuffer(destination);
-            if (bytesFromBuffer == destination.Length)
+            if (bytesFromBuffer == destination.Length && (destination.Length > 0 || !_allowForZeroByteReads))
             {
                 // We got as many bytes as were asked for; we're done.
                 return bytesFromBuffer;
@@ -561,7 +608,7 @@ namespace System.IO
             // If there was anything in the write buffer, clear it.
             if (_writePos > 0)
             {
-                FlushWrite();
+                FlushWrite(true);
             }
 
             if (destination.Length >= _bufferSize)
@@ -574,7 +621,7 @@ namespace System.IO
             {
                 // Otherwise, fill the buffer, then read from that.
                 EnsureBufferAllocated();
-                _readLen = _stream.Read(_buffer!, 0, _bufferSize);
+                _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
                 return ReadFromBuffer(destination) + bytesFromBuffer;
             }
         }
@@ -609,13 +656,13 @@ namespace System.IO
             // an Async operation.
             SemaphoreSlim sem = EnsureAsyncActiveSemaphoreInitialized();
             Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
-            if (semaphoreLockTask.IsCompletedSuccessfully)
+            bool locked = semaphoreLockTask.IsCompletedSuccessfully;
+            if (locked)
             {
-                bool completeSynchronously = true;
-                try
+                // hot path #1: there is data in the buffer
+                if (_readLen - _readPos > 0 || (count == 0 && !_allowForZeroByteReads))
                 {
-                    Exception? error;
-                    bytesFromBuffer = ReadFromBuffer(buffer, offset, count, out error);
+                    bytesFromBuffer = ReadFromBuffer(buffer, offset, count, out Exception? error);
 
                     // If we satisfied enough data from the buffer, we can complete synchronously.
                     // Reading again for more data may cause us to block if we're using a device with no clear end of file,
@@ -624,27 +671,35 @@ namespace System.IO
                     // BUT - this is a breaking change.
                     // So: If we could not read all bytes the user asked for from the buffer, we will try once from the underlying
                     // stream thus ensuring the same blocking behaviour as if the underlying stream was not wrapped in this BufferedStream.
-                    completeSynchronously = (bytesFromBuffer == count || error != null);
-
-                    if (completeSynchronously)
+                    if (bytesFromBuffer == count || error != null)
                     {
+                        // if the above is false, we will be entering ReadFromUnderlyingStreamAsync and releasing there.
+                        sem.Release();
 
                         return (error == null)
-                                    ? LastSyncCompletedReadTask(bytesFromBuffer)
-                                    : Task.FromException<int>(error);
+                            ? LastSyncCompletedReadTask(bytesFromBuffer)
+                            : Task.FromException<int>(error);
                     }
                 }
-                finally
+                // hot path #2: there is nothing to Flush and buffering would not be beneficial
+                else if (_writePos == 0 && count >= _bufferSize)
                 {
-                    if (completeSynchronously)  // if this is FALSE, we will be entering ReadFromUnderlyingStreamAsync and releasing there.
-                        sem.Release();
+                    _readPos = _readLen = 0;
+
+                    // start the async operation
+                    ValueTask<int> result = _stream!.ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken);
+
+                    // release the lock (we are not using shared state anymore)
+                    sem.Release();
+
+                    return result.AsTask();
                 }
             }
 
             // Delegate to the async implementation.
             return ReadFromUnderlyingStreamAsync(
                 new Memory<byte>(buffer, offset + bytesFromBuffer, count - bytesFromBuffer),
-                cancellationToken, bytesFromBuffer, semaphoreLockTask).AsTask();
+                cancellationToken, bytesFromBuffer, semaphoreLockTask, locked).AsTask();
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -660,38 +715,51 @@ namespace System.IO
             int bytesFromBuffer = 0;
             SemaphoreSlim sem = EnsureAsyncActiveSemaphoreInitialized();
             Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
-            if (semaphoreLockTask.IsCompletedSuccessfully)
+            bool locked = semaphoreLockTask.IsCompletedSuccessfully;
+            if (locked)
             {
-                bool completeSynchronously = true;
-                try
+                // hot path #1: there is data in the buffer
+                if (_readLen - _readPos > 0 || (buffer.Length == 0 && !_allowForZeroByteReads))
                 {
                     bytesFromBuffer = ReadFromBuffer(buffer.Span);
-                    completeSynchronously = bytesFromBuffer == buffer.Length;
-                    if (completeSynchronously)
+
+                    if (bytesFromBuffer == buffer.Length)
                     {
+                        // if above is FALSE, we will be entering ReadFromUnderlyingStreamAsync and releasing there.
+                        sem.Release();
+
                         // If we satisfied enough data from the buffer, we can complete synchronously.
                         return new ValueTask<int>(bytesFromBuffer);
                     }
+
+                    buffer = buffer.Slice(bytesFromBuffer);
                 }
-                finally
+                // hot path #2: there is nothing to Flush and buffering would not be beneficial
+                else if (_writePos == 0 && buffer.Length >= _bufferSize)
                 {
-                    if (completeSynchronously)  // if this is FALSE, we will be entering ReadFromUnderlyingStreamAsync and releasing there.
-                    {
-                        sem.Release();
-                    }
+                    _readPos = _readLen = 0;
+
+                    // start the async operation
+                    ValueTask<int> result = _stream!.ReadAsync(buffer, cancellationToken);
+
+                    // release the lock (we are not using shared state anymore)
+                    sem.Release();
+
+                    return result;
                 }
             }
 
             // Delegate to the async implementation.
-            return ReadFromUnderlyingStreamAsync(buffer.Slice(bytesFromBuffer), cancellationToken, bytesFromBuffer, semaphoreLockTask);
+            return ReadFromUnderlyingStreamAsync(buffer, cancellationToken, bytesFromBuffer, semaphoreLockTask, locked);
         }
 
         /// <summary>BufferedStream should be as thin a wrapper as possible. We want ReadAsync to delegate to
         /// ReadAsync of the underlying _stream rather than calling the base Stream which implements the one in terms of the other.
         /// This allows BufferedStream to affect the semantics of the stream it wraps as little as possible. </summary>
         /// <returns>-2 if _bufferSize was set to 0 while waiting on the semaphore; otherwise num of bytes read.</returns>
+        /// TODO: this method could benefit from IValueTaskSource (all the awaits allocate and we can take advantage of having single read op at a time)
         private async ValueTask<int> ReadFromUnderlyingStreamAsync(
-            Memory<byte> buffer, CancellationToken cancellationToken, int bytesAlreadySatisfied, Task semaphoreLockTask)
+            Memory<byte> buffer, CancellationToken cancellationToken, int bytesAlreadySatisfied, Task semaphoreLockTask, bool locked)
         {
             // Same conditions validated with exceptions in ReadAsync:
             Debug.Assert(_stream != null);
@@ -700,22 +768,32 @@ namespace System.IO
             Debug.Assert(_asyncActiveSemaphore != null);
             Debug.Assert(semaphoreLockTask != null);
 
-            // Employ async waiting based on the same synchronization used in BeginRead of the abstract Stream.
-            await semaphoreLockTask.ConfigureAwait(false);
+            if (!locked)
+            {
+                // Employ async waiting based on the same synchronization used in BeginRead of the abstract Stream.
+                await semaphoreLockTask.ConfigureAwait(false);
+            }
+
             try
             {
-                // The buffer might have been changed by another async task while we were waiting on the semaphore.
-                // Check it now again.
-                int bytesFromBuffer = ReadFromBuffer(buffer.Span);
-                if (bytesFromBuffer == buffer.Length)
-                {
-                    return bytesAlreadySatisfied + bytesFromBuffer;
-                }
+                int bytesFromBuffer = 0;
 
-                if (bytesFromBuffer > 0)
+                // we have already tried to read it from the buffer
+                if (!locked && (buffer.Length > 0 || !_allowForZeroByteReads))
                 {
-                    buffer = buffer.Slice(bytesFromBuffer);
-                    bytesAlreadySatisfied += bytesFromBuffer;
+                    // The buffer might have been changed by another async task while we were waiting on the semaphore.
+                    // Check it now again.
+                    bytesFromBuffer = ReadFromBuffer(buffer.Span);
+                    if (bytesFromBuffer == buffer.Length)
+                    {
+                        return bytesAlreadySatisfied + bytesFromBuffer;
+                    }
+
+                    if (bytesFromBuffer > 0)
+                    {
+                        buffer = buffer.Slice(bytesFromBuffer);
+                        bytesAlreadySatisfied += bytesFromBuffer;
+                    }
                 }
 
                 Debug.Assert(_readLen == _readPos);
@@ -773,7 +851,7 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (_writePos > 0)
-                FlushWrite();
+                FlushWrite(true);
 
             EnsureBufferAllocated();
             _readLen = _stream.Read(_buffer!, 0, _bufferSize);
@@ -1035,19 +1113,21 @@ namespace System.IO
             // Try to satisfy the request from the buffer synchronously.
             SemaphoreSlim sem = EnsureAsyncActiveSemaphoreInitialized();
             Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
-            if (semaphoreLockTask.IsCompletedSuccessfully)
+            bool locked = semaphoreLockTask.IsCompletedSuccessfully;
+            if (locked)
             {
                 bool completeSynchronously = true;
+
                 try
                 {
                     if (_writePos == 0)
                     {
-                        ClearReadBufferBeforeWrite();
+                        ClearReadBufferBeforeWrite(); // Seeks, but does not perform sync IO
                     }
 
                     Debug.Assert(_writePos < _bufferSize);
 
-                    // If the write completely fits into the buffer, we can complete synchronously:
+                    // hot path #1 If the write completely fits into the buffer, we can complete synchronously:
                     completeSynchronously = buffer.Length < _bufferSize - _writePos;
                     if (completeSynchronously)
                     {
@@ -1061,10 +1141,20 @@ namespace System.IO
                     if (completeSynchronously)  // if this is FALSE, we will be entering WriteToUnderlyingStreamAsync and releasing there.
                         sem.Release();
                 }
+
+                // hot path #2: there is nothing to Flush and buffering would not be beneficial
+                if (_writePos == 0 && buffer.Length >= _bufferSize)
+                {
+                    ValueTask result = _stream!.WriteAsync(buffer, cancellationToken);
+
+                    sem.Release();
+
+                    return result;
+                }
             }
 
             // Delegate to the async implementation.
-            return WriteToUnderlyingStreamAsync(buffer, cancellationToken, semaphoreLockTask);
+            return WriteToUnderlyingStreamAsync(buffer, cancellationToken, semaphoreLockTask, locked);
         }
 
         /// <summary>BufferedStream should be as thin a wrapper as possible. We want WriteAsync to delegate to
@@ -1073,7 +1163,7 @@ namespace System.IO
         /// little as possible.
         /// </summary>
         private async ValueTask WriteToUnderlyingStreamAsync(
-            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken, Task semaphoreLockTask)
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken, Task semaphoreLockTask, bool locked)
         {
             Debug.Assert(_stream != null);
             Debug.Assert(_stream.CanWrite);
@@ -1083,14 +1173,23 @@ namespace System.IO
 
             // See the LARGE COMMENT in Write(..) for the explanation of the write buffer algorithm.
 
-            await semaphoreLockTask.ConfigureAwait(false);
+            if (!locked)
+            {
+                await semaphoreLockTask.ConfigureAwait(false);
+            }
+
             try
             {
-                // The buffer might have been changed by another async task while we were waiting on the semaphore.
-                // However, note that if we recalculate the sync completion condition to TRUE, then useBuffer will also be TRUE.
+                if (!locked)
+                {
+                    // The buffer might have been changed by another async task while we were waiting on the semaphore.
+                    // However, note that if we recalculate the sync completion condition to TRUE, then useBuffer will also be TRUE.
 
-                if (_writePos == 0)
-                    ClearReadBufferBeforeWrite();
+                    if (_writePos == 0)
+                    {
+                        ClearReadBufferBeforeWrite();
+                    }
+                }
 
                 int totalUserBytes;
                 bool useBuffer;
@@ -1105,7 +1204,7 @@ namespace System.IO
                 {
                     buffer = buffer.Slice(WriteToBuffer(buffer.Span));
 
-                    if (_writePos < _bufferSize)
+                    if (_writePos < _buffer!.Length)
                     {
                         Debug.Assert(buffer.Length == 0);
                         return;
@@ -1165,6 +1264,18 @@ namespace System.IO
 
         public override void WriteByte(byte value)
         {
+            if (_writePos > 0 && _writePos < _bufferSize - 1)
+            {
+                _buffer![_writePos++] = value;
+            }
+            else
+            {
+                WriteByteSlow(value);
+            }
+        }
+
+        private void WriteByteSlow(byte value)
+        {
             EnsureNotClosed();
 
             if (_writePos == 0)
@@ -1176,7 +1287,7 @@ namespace System.IO
 
             // We should not be flushing here, but only writing to the underlying stream, but previous version flushed, so we keep this.
             if (_writePos >= _bufferSize - 1)
-                FlushWrite();
+                FlushWrite(true);
 
             _buffer![_writePos++] = value;
 
@@ -1194,7 +1305,7 @@ namespace System.IO
             {
                 // We should be only writing the buffer and not flushing,
                 // but the previous version did flush and we stick to it for back-compat reasons.
-                FlushWrite();
+                FlushWrite(true);
                 return _stream.Seek(offset, origin);
             }
 
@@ -1267,7 +1378,7 @@ namespace System.IO
             else if (_writePos > 0)
             {
                 // If there's write data in the buffer, flush it back to the underlying stream, as does ReadAsync.
-                FlushWrite();
+                FlushWrite(true);
             }
 
             // Our buffer is now clear. Copy data directly from the source stream to the destination stream.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamCompletionSource.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamCompletionSource.Win32.cs
@@ -9,8 +9,13 @@ using System.Threading.Tasks;
 
 namespace System.IO
 {
-    internal sealed partial class WindowsFileStreamStrategy : FileStreamStrategyBase
+    internal sealed partial class AsyncWindowsFileStreamStrategy : WindowsFileStreamStrategy
     {
+        /// <summary>
+        /// owned by BufferedStream, do NOT use outside of FileStreamCompletionSource
+        /// </summary>
+        private object? _buffer;
+
         // This is an internal object extending TaskCompletionSource with fields
         // for all of the relevant data necessary to complete the IO operation.
         // This is used by IOCallback and all of the async methods.
@@ -25,7 +30,7 @@ namespace System.IO
 
             private static Action<object?>? s_cancelCallback;
 
-            private readonly WindowsFileStreamStrategy _stream;
+            private readonly AsyncWindowsFileStreamStrategy _stream;
             private readonly int _numBufferedBytes;
             private CancellationTokenRegistration _cancellationRegistration;
 #if DEBUG
@@ -35,7 +40,7 @@ namespace System.IO
             private long _result; // Using long since this needs to be used in Interlocked APIs
 
             // Using RunContinuationsAsynchronously for compat reasons (old API used Task.Factory.StartNew for continuations)
-            protected FileStreamCompletionSource(WindowsFileStreamStrategy stream, int numBufferedBytes, byte[]? bytes)
+            protected FileStreamCompletionSource(AsyncWindowsFileStreamStrategy stream, int numBufferedBytes, byte[]? bytes)
                 : base(TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 _numBufferedBytes = numBufferedBytes;
@@ -132,8 +137,8 @@ namespace System.IO
                 // be directly the FileStreamCompletionSource that's completing (in the case where the preallocated
                 // overlapped was already in use by another operation).
                 object? state = ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
-                Debug.Assert(state is WindowsFileStreamStrategy || state is FileStreamCompletionSource);
-                FileStreamCompletionSource completionSource = state is WindowsFileStreamStrategy fs ?
+                Debug.Assert(state is AsyncWindowsFileStreamStrategy || state is FileStreamCompletionSource);
+                FileStreamCompletionSource completionSource = state is AsyncWindowsFileStreamStrategy fs ?
                     fs._currentOverlappedOwner! : // must be owned
                     (FileStreamCompletionSource)state!;
                 Debug.Assert(completionSource != null);
@@ -220,7 +225,7 @@ namespace System.IO
                 }
             }
 
-            public static FileStreamCompletionSource Create(WindowsFileStreamStrategy stream, int numBufferedBytesRead, ReadOnlyMemory<byte> memory)
+            public static FileStreamCompletionSource Create(AsyncWindowsFileStreamStrategy stream, int numBufferedBytesRead, ReadOnlyMemory<byte> memory)
             {
                 // If the memory passed in is the stream's internal buffer, we can use the base FileStreamCompletionSource,
                 // which has a PreAllocatedOverlapped with the memory already pinned.  Otherwise, we use the derived
@@ -241,7 +246,7 @@ namespace System.IO
         {
             private MemoryHandle _handle; // mutable struct; do not make this readonly
 
-            internal MemoryFileStreamCompletionSource(WindowsFileStreamStrategy stream, int numBufferedBytes, ReadOnlyMemory<byte> memory) :
+            internal MemoryFileStreamCompletionSource(AsyncWindowsFileStreamStrategy stream, int numBufferedBytes, ReadOnlyMemory<byte> memory) :
                 base(stream, numBufferedBytes, bytes: null) // this type handles the pinning, so null is passed for bytes
             {
                 _handle = memory.Pin();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamStrategy.cs
@@ -7,10 +7,6 @@ namespace System.IO
 {
     internal abstract class FileStreamStrategy : Stream
     {
-        protected readonly FileStream _fileStream;
-
-        protected FileStreamStrategy(FileStream fileStream) => _fileStream = fileStream;
-
         internal abstract bool IsAsync { get; }
 
         internal abstract string Name { get; }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SyncWindowsFileStreamStrategy.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.CompilerServices;
+
+/*
+ * Win32FileStream supports different modes of accessing the disk - async mode
+ * and sync mode.  They are two completely different codepaths in the
+ * sync & async methods (i.e. Read/Write vs. ReadAsync/WriteAsync).  File
+ * handles in NT can be opened in only sync or overlapped (async) mode,
+ * and we have to deal with this pain.  Stream has implementations of
+ * the sync methods in terms of the async ones, so we'll
+ * call through to our base class to get those methods when necessary.
+ *
+ * Also buffering is added into Win32FileStream as well. Folded in the
+ * code from BufferedStream, so all the comments about it being mostly
+ * aggressive (and the possible perf improvement) apply to Win32FileStream as
+ * well.  Also added some buffering to the async code paths.
+ *
+ * Class Invariants:
+ * The class has one buffer, shared for reading & writing.  It can only be
+ * used for one or the other at any point in time - not both.  The following
+ * should be true:
+ *   0 <= _readPos <= _readLen < _bufferSize
+ *   0 <= _writePos < _bufferSize
+ *   _readPos == _readLen && _readPos > 0 implies the read buffer is valid,
+ *     but we're at the end of the buffer.
+ *   _readPos == _readLen == 0 means the read buffer contains garbage.
+ *   Either _writePos can be greater than 0, or _readLen & _readPos can be
+ *     greater than zero, but neither can be greater than zero at the same time.
+ *
+ */
+
+namespace System.IO
+{
+    internal sealed class SyncWindowsFileStreamStrategy : WindowsFileStreamStrategy
+    {
+        internal SyncWindowsFileStreamStrategy(SafeFileHandle handle, FileAccess access) : base(handle, access)
+        {
+        }
+
+        internal SyncWindowsFileStreamStrategy(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)
+            : base(path, mode, access, share, options)
+        {
+        }
+
+        internal override bool IsAsync => false;
+
+        protected override void OnInitFromHandle(SafeFileHandle handle)
+        {
+            // As we can accurately check the handle type when we have access to NtQueryInformationFile we don't need to skip for
+            // any particular file handle type.
+
+            // If the handle was passed in without an explicit async setting, we already looked it up in GetDefaultIsAsync
+            if (!handle.IsAsync.HasValue)
+                return;
+
+            // If we can't check the handle, just assume it is ok.
+            if (!(FileStreamHelpers.IsHandleSynchronous(handle, ignoreInvalid: false) ?? true))
+                throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => ReadSpan(new Span<byte>(buffer, offset, count));
+
+        public override int Read(Span<byte> buffer) => ReadSpan(buffer);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // If we weren't opened for asynchronous I/O, we still call to the base implementation so that
+            // Read is invoked asynchronously.  But we can do so using the base Stream's internal helper
+            // that bypasses delegating to BeginRead, since we already know this is FileStream rather
+            // than something derived from it and what our BeginRead implementation is going to do.
+            return (Task<int>)BeginReadInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // If we weren't opened for asynchronous I/O, we still call to the base implementation so that
+            // Read is invoked asynchronously.  But if we have a byte[], we can do so using the base Stream's
+            // internal helper that bypasses delegating to BeginRead, since we already know this is FileStream
+            // rather than something derived from it and what our BeginRead implementation is going to do.
+            return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
+                new ValueTask<int>((Task<int>)BeginReadInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                base.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => WriteSpan(new ReadOnlySpan<byte>(buffer, offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            WriteSpan(buffer);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // If we weren't opened for asynchronous I/O, we still call to the base implementation so that
+            // Write is invoked asynchronously.  But we can do so using the base Stream's internal helper
+            // that bypasses delegating to BeginWrite, since we already know this is FileStream rather
+            // than something derived from it and what our BeginWrite implementation is going to do.
+            return (Task)BeginWriteInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // If we weren't opened for asynchronous I/O, we still call to the base implementation so that
+            // Write is invoked asynchronously.  But if we have a byte[], we can do so using the base Stream's
+            // internal helper that bypasses delegating to BeginWrite, since we already know this is FileStream
+            // rather than something derived from it and what our BeginWrite implementation is going to do.
+            return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
+                new ValueTask((Task)BeginWriteInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                base.WriteAsync(buffer, cancellationToken);
+        }
+
+        private unsafe int ReadSpan(Span<byte> destination)
+        {
+            Debug.Assert(CanRead, "BufferedStream has already verified that");
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+
+            // Make sure we are reading from the right spot
+            VerifyOSHandlePosition();
+
+            int r = ReadFileNative(_fileHandle, destination, null, out int errorCode);
+
+            if (r == -1)
+            {
+                // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
+                if (errorCode == ERROR_BROKEN_PIPE)
+                {
+                    r = 0;
+                }
+                else
+                {
+                    if (errorCode == ERROR_INVALID_PARAMETER)
+                        throw new ArgumentException(SR.Arg_HandleNotSync, "_fileHandle");
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                }
+            }
+            Debug.Assert(r >= 0, "FileStream's ReadNative is likely broken.");
+            _filePosition += r;
+
+            return r;
+        }
+
+        private unsafe void WriteSpan(ReadOnlySpan<byte> source)
+        {
+            Debug.Assert(CanWrite, "BufferedStream has already verified that");
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+
+            // Make sure we are writing to the position that we think we are
+            VerifyOSHandlePosition();
+
+            int r = WriteFileNative(_fileHandle, source, null, out int errorCode);
+
+            if (r == -1)
+            {
+                // For pipes, ERROR_NO_DATA is not an error, but the pipe is closing.
+                if (errorCode == ERROR_NO_DATA)
+                {
+                    r = 0;
+                }
+                else
+                {
+                    // ERROR_INVALID_PARAMETER may be returned for writes
+                    // where the position is too large or for synchronous writes
+                    // to a handle opened asynchronously.
+                    if (errorCode == ERROR_INVALID_PARAMETER)
+                        throw new IOException(SR.IO_FileTooLongOrHandleNotSync);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                }
+            }
+            Debug.Assert(r >= 0, "FileStream's WriteCore is likely broken.");
+            _filePosition += r;
+            return;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SyncWindowsFileStreamStrategy.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
-using System.Runtime.CompilerServices;
 
 /*
  * Win32FileStream supports different modes of accessing the disk - async mode
@@ -17,24 +15,6 @@ using System.Runtime.CompilerServices;
  * and we have to deal with this pain.  Stream has implementations of
  * the sync methods in terms of the async ones, so we'll
  * call through to our base class to get those methods when necessary.
- *
- * Also buffering is added into Win32FileStream as well. Folded in the
- * code from BufferedStream, so all the comments about it being mostly
- * aggressive (and the possible perf improvement) apply to Win32FileStream as
- * well.  Also added some buffering to the async code paths.
- *
- * Class Invariants:
- * The class has one buffer, shared for reading & writing.  It can only be
- * used for one or the other at any point in time - not both.  The following
- * should be true:
- *   0 <= _readPos <= _readLen < _bufferSize
- *   0 <= _writePos < _bufferSize
- *   _readPos == _readLen && _readPos > 0 implies the read buffer is valid,
- *     but we're at the end of the buffer.
- *   _readPos == _readLen == 0 means the read buffer contains garbage.
- *   Either _writePos can be greater than 0, or _readLen & _readPos can be
- *     greater than zero, but neither can be greater than zero at the same time.
- *
  */
 
 namespace System.IO

--- a/src/libraries/System.Private.CoreLib/src/System/IO/WindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/WindowsFileStreamStrategy.cs
@@ -39,29 +39,247 @@ using System.Runtime.CompilerServices;
 
 namespace System.IO
 {
-    internal sealed partial class WindowsFileStreamStrategy : FileStreamStrategyBase
+    internal abstract class WindowsFileStreamStrategy : FileStreamStrategy
     {
-        private bool _canSeek;
-        private bool _isPipe;      // Whether to disable async buffering code.
+        // Error codes (not HRESULTS), from winerror.h
+        internal const int ERROR_BROKEN_PIPE = 109;
+        internal const int ERROR_NO_DATA = 232;
+        protected const int ERROR_HANDLE_EOF = 38;
+        protected const int ERROR_INVALID_PARAMETER = 87;
+        protected const int ERROR_IO_PENDING = 997;
+
+        protected readonly SafeFileHandle _fileHandle; // only ever null if ctor throws
+
+        /// <summary>Whether the file is opened for reading, writing, or both.</summary>
+        private readonly FileAccess _access;
+
+        /// <summary>The path to the opened file.</summary>
+        protected readonly string? _path;
+
+        protected long _filePosition;
+
+        private readonly bool _canSeek;
+        private readonly bool _isPipe;      // Whether to disable async buffering code.
+
+        /// <summary>Whether the file stream's handle has been exposed.</summary>
+        protected bool _exposedHandle;
+
         private long _appendStart; // When appending, prevent overwriting file.
 
-        private static readonly unsafe IOCompletionCallback s_ioCallback = FileStreamCompletionSource.IOCallback;
-
-        private Task _activeBufferOperation = Task.CompletedTask;    // tracks in-progress async ops using the buffer
-        private PreAllocatedOverlapped? _preallocatedOverlapped;     // optimization for async ops to avoid per-op allocations
-        private FileStreamCompletionSource? _currentOverlappedOwner; // async op currently using the preallocated overlapped
-
-        internal WindowsFileStreamStrategy(FileStream fileStream, SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
-            : base(fileStream, handle, access, bufferSize, isAsync)
+        internal WindowsFileStreamStrategy(SafeFileHandle handle, FileAccess access)
         {
+            _exposedHandle = true;
+
+            InitFromHandle(handle, access, out _canSeek, out _isPipe);
+
+            // Note: Cleaner to set the following fields in ValidateAndInitFromHandle,
+            // but we can't as they're readonly.
+            _access = access;
+
+            // As the handle was passed in, we must set the handle field at the very end to
+            // avoid the finalizer closing the handle when we throw errors.
+            _fileHandle = handle;
         }
 
-        internal WindowsFileStreamStrategy(FileStream fileStream, string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
-            : base(fileStream, path, mode, access, share, bufferSize, options)
+        internal WindowsFileStreamStrategy(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)
         {
+            string fullPath = Path.GetFullPath(path);
+
+            _path = fullPath;
+            _access = access;
+
+            _fileHandle = FileStreamHelpers.OpenHandle(fullPath, mode, access, share, options);
+
+            try
+            {
+                _canSeek = true;
+
+                Init(mode, path);
+            }
+            catch
+            {
+                // If anything goes wrong while setting up the stream, make sure we deterministically dispose
+                // of the opened handle.
+                _fileHandle.Dispose();
+                _fileHandle = null!;
+                throw;
+            }
         }
 
-        protected override void Init(FileMode mode, FileShare share, string originalPath, FileOptions options)
+        public sealed override bool CanSeek => _canSeek;
+
+        public sealed override bool CanRead => !_fileHandle.IsClosed && (_access & FileAccess.Read) != 0;
+
+        public sealed override bool CanWrite => !_fileHandle.IsClosed && (_access & FileAccess.Write) != 0;
+
+        public unsafe sealed override long Length
+        {
+            get
+            {
+                Interop.Kernel32.FILE_STANDARD_INFO info;
+
+                if (!Interop.Kernel32.GetFileInformationByHandleEx(_fileHandle, Interop.Kernel32.FileStandardInfo, &info, (uint)sizeof(Interop.Kernel32.FILE_STANDARD_INFO)))
+                {
+                    throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+                }
+
+                return info.EndOfFile;
+            }
+        }
+
+        /// <summary>Gets or sets the position within the current stream</summary>
+        public override long Position
+        {
+            get
+            {
+                VerifyOSHandlePosition();
+
+                return _filePosition;
+            }
+            set
+            {
+                Seek(value, SeekOrigin.Begin);
+            }
+        }
+
+        internal sealed override string Name => _path ?? SR.IO_UnknownFileName;
+
+        internal sealed override bool IsClosed => _fileHandle.IsClosed;
+
+        internal sealed override SafeFileHandle SafeFileHandle
+        {
+            get
+            {
+                // Flushing is the responsibility of BufferedFileStreamStrategy
+                _exposedHandle = true;
+                return _fileHandle;
+            }
+        }
+
+        // this method just disposes everything as there is no buffer here
+        // and we don't really need to Flush anything here
+        public override ValueTask DisposeAsync()
+        {
+            if (_fileHandle != null && !_fileHandle.IsClosed)
+            {
+                _fileHandle.ThreadPoolBinding?.Dispose();
+                _fileHandle.Dispose();
+            }
+
+            GC.SuppressFinalize(this); // the handle is closed; nothing further for the finalizer to do
+
+            return ValueTask.CompletedTask;
+        }
+
+        // this method in the future will be called in no-buffering scenarios
+        internal sealed override void DisposeInternal(bool disposing) => Dispose(disposing);
+
+        // this method is called from BufferedStream.Dispose so the content is already flushed
+        protected override void Dispose(bool disposing)
+        {
+            if (_fileHandle != null && !_fileHandle.IsClosed)
+            {
+                _fileHandle.ThreadPoolBinding?.Dispose();
+                _fileHandle.Dispose();
+            }
+
+            // Don't set the buffer to null, to avoid a NullReferenceException
+            // when users have a race condition in their code (i.e. they call
+            // Close when calling another method on Stream like Read).
+        }
+
+        public sealed override void Flush() => Flush(flushToDisk: false); // we have nothing to flush as there is no buffer here
+
+        internal sealed override void Flush(bool flushToDisk)
+        {
+            if (flushToDisk && CanWrite)
+            {
+                if (!Interop.Kernel32.FlushFileBuffers(_fileHandle))
+                {
+                    throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+                }
+            }
+        }
+
+        public sealed override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
+                throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin));
+            if (_fileHandle.IsClosed) throw Error.GetFileNotOpen();
+            if (!CanSeek) throw Error.GetSeekNotSupported();
+
+            // Verify that internal position is in sync with the handle
+            VerifyOSHandlePosition();
+
+            long oldPos = _filePosition;
+            long pos = SeekCore(_fileHandle, offset, origin);
+
+            // Prevent users from overwriting data in a file that was opened in
+            // append mode.
+            if (_appendStart != -1 && pos < _appendStart)
+            {
+                SeekCore(_fileHandle, oldPos, SeekOrigin.Begin);
+                throw new IOException(SR.IO_SeekAppendOverwrite);
+            }
+
+            return pos;
+        }
+
+        // This doesn't do argument checking.  Necessary for SetLength, which must
+        // set the file pointer beyond the end of the file. This will update the
+        // internal position
+        protected long SeekCore(SafeFileHandle fileHandle, long offset, SeekOrigin origin, bool closeInvalidHandle = false)
+        {
+            Debug.Assert(!fileHandle.IsClosed && _canSeek, "!fileHandle.IsClosed && _canSeek");
+            Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End, "origin >= SeekOrigin.Begin && origin <= SeekOrigin.End");
+
+            if (!Interop.Kernel32.SetFilePointerEx(fileHandle, offset, out long ret, (uint)origin))
+            {
+                if (closeInvalidHandle)
+                {
+                    throw Win32Marshal.GetExceptionForWin32Error(GetLastWin32ErrorAndDisposeHandleIfInvalid(), _path);
+                }
+                else
+                {
+                    throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+                }
+            }
+
+            _filePosition = ret;
+            return ret;
+        }
+
+        internal sealed override void Lock(long position, long length)
+        {
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.Kernel32.LockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+            }
+        }
+
+        internal sealed override void Unlock(long position, long length)
+        {
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.Kernel32.UnlockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+            }
+        }
+
+        protected abstract void OnInitFromHandle(SafeFileHandle handle);
+
+        protected virtual void OnInit() { }
+
+        private void Init(FileMode mode, string originalPath)
         {
             if (!PathInternal.IsExtended(originalPath))
             {
@@ -86,36 +304,7 @@ namespace System.IO
                 }
             }
 
-            // This is necessary for async IO using IO Completion ports via our
-            // managed Threadpool API's.  This (theoretically) calls the OS's
-            // BindIoCompletionCallback method, and passes in a stub for the
-            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
-            // struct for this request and gets a delegate to a managed callback
-            // from there, which it then calls on a threadpool thread.  (We allocate
-            // our native OVERLAPPED structs 2 pointers too large and store EE state
-            // & GC handles there, one to an IAsyncResult, the other to a delegate.)
-            if (_useAsyncIO)
-            {
-                try
-                {
-                    _fileHandle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(_fileHandle);
-                }
-                catch (ArgumentException ex)
-                {
-                    throw new IOException(SR.IO_BindHandleFailed, ex);
-                }
-                finally
-                {
-                    if (_fileHandle.ThreadPoolBinding == null)
-                    {
-                        // We should close the handle so that the handle is not open until SafeFileHandle GC
-                        Debug.Assert(!_exposedHandle, "Are we closing handle that we exposed/not own, how?");
-                        _fileHandle.Dispose();
-                    }
-                }
-            }
-
-            _canSeek = true;
+            OnInit();
 
             // For Append mode...
             if (mode == FileMode.Append)
@@ -128,7 +317,7 @@ namespace System.IO
             }
         }
 
-        protected override void InitFromHandle(SafeFileHandle handle, FileAccess access, bool useAsyncIO)
+        private void InitFromHandle(SafeFileHandle handle, FileAccess access, out bool canSeek, out bool isPipe)
         {
 #if DEBUG
             bool hadBinding = handle.ThreadPoolBinding != null;
@@ -136,7 +325,7 @@ namespace System.IO
             try
             {
 #endif
-                InitFromHandleImpl(handle, useAsyncIO);
+                InitFromHandleImpl(handle, out canSeek, out isPipe);
 #if DEBUG
             }
             catch
@@ -147,43 +336,15 @@ namespace System.IO
 #endif
         }
 
-        private void InitFromHandleImpl(SafeFileHandle handle, bool useAsyncIO)
+        private void InitFromHandleImpl(SafeFileHandle handle, out bool canSeek, out bool isPipe)
         {
             int handleType = Interop.Kernel32.GetFileType(handle);
             Debug.Assert(handleType == Interop.Kernel32.FileTypes.FILE_TYPE_DISK || handleType == Interop.Kernel32.FileTypes.FILE_TYPE_PIPE || handleType == Interop.Kernel32.FileTypes.FILE_TYPE_CHAR, "FileStream was passed an unknown file type!");
 
-            _canSeek = handleType == Interop.Kernel32.FileTypes.FILE_TYPE_DISK;
-            _isPipe = handleType == Interop.Kernel32.FileTypes.FILE_TYPE_PIPE;
+            canSeek = handleType == Interop.Kernel32.FileTypes.FILE_TYPE_DISK;
+            isPipe = handleType == Interop.Kernel32.FileTypes.FILE_TYPE_PIPE;
 
-            // This is necessary for async IO using IO Completion ports via our
-            // managed Threadpool API's.  This calls the OS's
-            // BindIoCompletionCallback method, and passes in a stub for the
-            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
-            // struct for this request and gets a delegate to a managed callback
-            // from there, which it then calls on a threadpool thread.  (We allocate
-            // our native OVERLAPPED structs 2 pointers too large and store EE
-            // state & a handle to a delegate there.)
-            //
-            // If, however, we've already bound this file handle to our completion port,
-            // don't try to bind it again because it will fail.  A handle can only be
-            // bound to a single completion port at a time.
-            if (useAsyncIO && !(handle.IsAsync ?? false))
-            {
-                try
-                {
-                    handle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(handle);
-                }
-                catch (Exception ex)
-                {
-                    // If you passed in a synchronous handle and told us to use
-                    // it asynchronously, throw here.
-                    throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle), ex);
-                }
-            }
-            else if (!useAsyncIO)
-            {
-                FileStreamHelpers.VerifyHandleIsSync(handle);
-            }
+            OnInitFromHandle(handle);
 
             if (_canSeek)
                 SeekCore(handle, 0, SeekOrigin.Current);
@@ -191,189 +352,17 @@ namespace System.IO
                 _filePosition = 0;
         }
 
-        private bool HasActiveBufferOperation => !_activeBufferOperation.IsCompleted;
-
-        public override bool CanSeek => _canSeek;
-
-        public unsafe override long Length
+        public sealed override void SetLength(long value)
         {
-            get
-            {
-                Interop.Kernel32.FILE_STANDARD_INFO info;
-
-                if (!Interop.Kernel32.GetFileInformationByHandleEx(_fileHandle, Interop.Kernel32.FileStandardInfo, &info, (uint)sizeof(Interop.Kernel32.FILE_STANDARD_INFO)))
-                    throw Win32Marshal.GetExceptionForLastWin32Error(_path);
-                long len = info.EndOfFile;
-
-                // If we're writing near the end of the file, we must include our
-                // internal buffer in our Length calculation.  Don't flush because
-                // we use the length of the file in our async write method.
-                if (_writePos > 0 && _filePosition + _writePos > len)
-                    len = _writePos + _filePosition;
-
-                return len;
-            }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            // Nothing will be done differently based on whether we are
-            // disposing vs. finalizing.  This is taking advantage of the
-            // weak ordering between normal finalizable objects & critical
-            // finalizable objects, which I included in the SafeHandle
-            // design for Win32FileStream, which would often "just work" when
-            // finalized.
-            try
-            {
-                if (_fileHandle != null && !_fileHandle.IsClosed && _writePos > 0)
-                {
-                    // Flush data to disk iff we were writing.  After
-                    // thinking about this, we also don't need to flush
-                    // our read position, regardless of whether the handle
-                    // was exposed to the user.  They probably would NOT
-                    // want us to do this.
-                    try
-                    {
-                        FlushWriteBuffer(!disposing);
-                    }
-                    catch (Exception e) when (IsIoRelatedException(e) && !disposing)
-                    {
-                        // On finalization, ignore failures from trying to flush the write buffer,
-                        // e.g. if this stream is wrapping a pipe and the pipe is now broken.
-                    }
-                }
-            }
-            finally
-            {
-                if (_fileHandle != null && !_fileHandle.IsClosed)
-                {
-                    _fileHandle.ThreadPoolBinding?.Dispose();
-                    _fileHandle.Dispose();
-                }
-
-                _preallocatedOverlapped?.Dispose();
-                _canSeek = false;
-
-                // Don't set the buffer to null, to avoid a NullReferenceException
-                // when users have a race condition in their code (i.e. they call
-                // Close when calling another method on Stream like Read).
-            }
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            // Same logic as in Dispose(), except with async counterparts.
-            // TODO: https://github.com/dotnet/runtime/issues/27643: FlushAsync does synchronous work.
-            try
-            {
-                if (_fileHandle != null && !_fileHandle.IsClosed && _writePos > 0)
-                {
-                    await FlushAsync(default).ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                if (_fileHandle != null && !_fileHandle.IsClosed)
-                {
-                    _fileHandle.ThreadPoolBinding?.Dispose();
-                    _fileHandle.Dispose();
-                }
-
-                _preallocatedOverlapped?.Dispose();
-                _canSeek = false;
-                GC.SuppressFinalize(this); // the handle is closed; nothing further for the finalizer to do
-            }
-        }
-
-        protected override void FlushOSBuffer()
-        {
-            if (!Interop.Kernel32.FlushFileBuffers(_fileHandle))
-            {
-                throw Win32Marshal.GetExceptionForLastWin32Error(_path);
-            }
-        }
-
-        // Returns a task that flushes the internal write buffer
-        private Task FlushWriteAsync(CancellationToken cancellationToken)
-        {
-            Debug.Assert(_useAsyncIO);
-            Debug.Assert(_readPos == 0 && _readLength == 0, "FileStream: Read buffer must be empty in FlushWriteAsync!");
-
-            // If the buffer is already flushed, don't spin up the OS write
-            if (_writePos == 0) return Task.CompletedTask;
-
-            Task flushTask = WriteAsyncInternalCore(new ReadOnlyMemory<byte>(GetBuffer(), 0, _writePos), cancellationToken);
-            _writePos = 0;
-
-            // Update the active buffer operation
-            _activeBufferOperation = HasActiveBufferOperation ?
-                Task.WhenAll(_activeBufferOperation, flushTask) :
-                flushTask;
-
-            return flushTask;
-        }
-
-        protected override void FlushWriteBufferForWriteByte() => FlushWriteBuffer();
-
-        // Writes are buffered.  Anytime the buffer fills up
-        // (_writePos + delta > _bufferSize) or the buffer switches to reading
-        // and there is left over data (_writePos > 0), this function must be called.
-        protected override void FlushWriteBuffer(bool calledFromFinalizer = false)
-        {
-            if (_writePos == 0) return;
-            Debug.Assert(_readPos == 0 && _readLength == 0, "FileStream: Read buffer must be empty in FlushWrite!");
-
-            if (_useAsyncIO)
-            {
-                Task writeTask = FlushWriteAsync(CancellationToken.None);
-                // With our Whidbey async IO & overlapped support for AD unloads,
-                // we don't strictly need to block here to release resources
-                // since that support takes care of the pinning & freeing the
-                // overlapped struct.  We need to do this when called from
-                // Close so that the handle is closed when Close returns, but
-                // we don't need to call EndWrite from the finalizer.
-                // Additionally, if we do call EndWrite, we block forever
-                // because AD unloads prevent us from running the managed
-                // callback from the IO completion port.  Blocking here when
-                // called from the finalizer during AD unload is clearly wrong,
-                // but we can't use any sort of test for whether the AD is
-                // unloading because if we weren't unloading, an AD unload
-                // could happen on a separate thread before we call EndWrite.
-                if (!calledFromFinalizer)
-                {
-                    writeTask.GetAwaiter().GetResult();
-                }
-            }
-            else
-            {
-                WriteCore(new ReadOnlySpan<byte>(GetBuffer(), 0, _writePos));
-            }
-
-            _writePos = 0;
-        }
-
-        public override void SetLength(long value)
-        {
-            // Handle buffering updates.
-            if (_writePos > 0)
-            {
-                FlushWriteBuffer();
-            }
-            else if (_readPos < _readLength)
-            {
-                FlushReadBuffer();
-            }
-            _readPos = 0;
-            _readLength = 0;
-
             if (_appendStart != -1 && value < _appendStart)
                 throw new IOException(SR.IO_SetLengthAppendTruncate);
+
             SetLengthCore(value);
         }
 
         // We absolutely need this method broken out so that WriteInternalCoreAsync can call
         // a method without having to go through buffering code that might call FlushWrite.
-        private unsafe void SetLengthCore(long value)
+        protected unsafe void SetLengthCore(long value)
         {
             Debug.Assert(value >= 0, "value >= 0");
             VerifyOSHandlePosition();
@@ -401,812 +390,34 @@ namespace System.IO
             }
         }
 
-        // Instance method to help code external to this MarshalByRefObject avoid
-        // accessing its fields by ref.  This avoids a compiler warning.
-        private FileStreamCompletionSource? CompareExchangeCurrentOverlappedOwner(FileStreamCompletionSource? newSource, FileStreamCompletionSource? existingSource) =>
-            Interlocked.CompareExchange(ref _currentOverlappedOwner, newSource, existingSource);
-
-        protected override int ReadSpan(Span<byte> destination)
+        /// <summary>
+        /// Verify that the actual position of the OS's handle equals what we expect it to.
+        /// This will fail if someone else moved the UnixFileStream's handle or if
+        /// our position updating code is incorrect.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void VerifyOSHandlePosition()
         {
-            Debug.Assert(!_useAsyncIO, "Must only be used when in synchronous mode");
-            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength),
-                "We're either reading or writing, but not both.");
-
-            bool isBlocked = false;
-            int n = _readLength - _readPos;
-            // if the read buffer is empty, read into either user's array or our
-            // buffer, depending on number of bytes user asked for and buffer size.
-            if (n == 0)
+            bool verifyPosition = _exposedHandle; // in release, only verify if we've given out the handle such that someone else could be manipulating it
+#if DEBUG
+            verifyPosition = true; // in debug, always make sure our position matches what the OS says it should be
+#endif
+            if (verifyPosition && CanSeek)
             {
-                if (!CanRead) throw Error.GetReadNotSupported();
-                if (_writePos > 0) FlushWriteBuffer();
-                if (!CanSeek || (destination.Length >= _bufferLength))
+                long oldPos = _filePosition; // SeekCore will override the current _position, so save it now
+                long curPos = SeekCore(_fileHandle, 0, SeekOrigin.Current);
+                if (oldPos != curPos)
                 {
-                    n = ReadNative(destination);
-                    // Throw away read buffer.
-                    _readPos = 0;
-                    _readLength = 0;
-                    return n;
-                }
-                n = ReadNative(GetBuffer());
-                if (n == 0) return 0;
-                isBlocked = n < _bufferLength;
-                _readPos = 0;
-                _readLength = n;
-            }
-            // Now copy min of count or numBytesAvailable (i.e. near EOF) to array.
-            if (n > destination.Length) n = destination.Length;
-            new ReadOnlySpan<byte>(GetBuffer(), _readPos, n).CopyTo(destination);
-            _readPos += n;
+                    // For reads, this is non-fatal but we still could have returned corrupted
+                    // data in some cases, so discard the internal buffer. For writes,
+                    // this is a problem; discard the buffer and error out.
 
-            // We may have read less than the number of bytes the user asked
-            // for, but that is part of the Stream contract.  Reading again for
-            // more data may cause us to block if we're using a device with
-            // no clear end of file, such as a serial port or pipe.  If we
-            // blocked here & this code was used with redirected pipes for a
-            // process's standard output, this can lead to deadlocks involving
-            // two processes. But leave this here for files to avoid what would
-            // probably be a breaking change.         --
-
-            // If we are reading from a device with no clear EOF like a
-            // serial port or a pipe, this will cause us to block incorrectly.
-            if (!_isPipe)
-            {
-                // If we hit the end of the buffer and didn't have enough bytes, we must
-                // read some more from the underlying stream.  However, if we got
-                // fewer bytes from the underlying stream than we asked for (i.e. we're
-                // probably blocked), don't ask for more bytes.
-                if (n < destination.Length && !isBlocked)
-                {
-                    Debug.Assert(_readPos == _readLength, "Read buffer should be empty!");
-                    int moreBytesRead = ReadNative(destination.Slice(n));
-                    n += moreBytesRead;
-                    // We've just made our buffer inconsistent with our position
-                    // pointer.  We must throw away the read buffer.
-                    _readPos = 0;
-                    _readLength = 0;
-                }
-            }
-
-            return n;
-        }
-
-        [Conditional("DEBUG")]
-        private void AssertCanRead()
-        {
-            Debug.Assert(!_fileHandle.IsClosed, "!_fileHandle.IsClosed");
-            Debug.Assert(CanRead, "CanRead");
-        }
-
-        /// <summary>Reads from the file handle into the buffer, overwriting anything in it.</summary>
-        protected override int FillReadBufferForReadByte() =>
-            _useAsyncIO ?
-                ReadNativeAsync(new Memory<byte>(_buffer), 0, CancellationToken.None).GetAwaiter().GetResult() :
-                ReadNative(_buffer);
-
-        private unsafe int ReadNative(Span<byte> buffer)
-        {
-            Debug.Assert(!_useAsyncIO, $"{nameof(ReadNative)} doesn't work on asynchronous file streams.");
-            AssertCanRead();
-
-            // Make sure we are reading from the right spot
-            VerifyOSHandlePosition();
-
-            int r = ReadFileNative(_fileHandle, buffer, null, out int errorCode);
-
-            if (r == -1)
-            {
-                // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
-                if (errorCode == ERROR_BROKEN_PIPE)
-                {
-                    r = 0;
-                }
-                else
-                {
-                    if (errorCode == ERROR_INVALID_PARAMETER)
-                        throw new ArgumentException(SR.Arg_HandleNotSync, "_fileHandle");
-
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                }
-            }
-            Debug.Assert(r >= 0, "FileStream's ReadNative is likely broken.");
-            _filePosition += r;
-
-            return r;
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
-                throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin));
-            if (_fileHandle.IsClosed) throw Error.GetFileNotOpen();
-            if (!CanSeek) throw Error.GetSeekNotSupported();
-
-            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
-
-            // If we've got bytes in our buffer to write, write them out.
-            // If we've read in and consumed some bytes, we'll have to adjust
-            // our seek positions ONLY IF we're seeking relative to the current
-            // position in the stream.  This simulates doing a seek to the new
-            // position, then a read for the number of bytes we have in our buffer.
-            if (_writePos > 0)
-            {
-                FlushWriteBuffer();
-            }
-            else if (origin == SeekOrigin.Current)
-            {
-                // Don't call FlushRead here, which would have caused an infinite
-                // loop.  Simply adjust the seek origin.  This isn't necessary
-                // if we're seeking relative to the beginning or end of the stream.
-                offset -= (_readLength - _readPos);
-            }
-            _readPos = _readLength = 0;
-
-            // Verify that internal position is in sync with the handle
-            VerifyOSHandlePosition();
-
-            long oldPos = _filePosition + (_readPos - _readLength);
-            long pos = SeekCore(_fileHandle, offset, origin);
-
-            // Prevent users from overwriting data in a file that was opened in
-            // append mode.
-            if (_appendStart != -1 && pos < _appendStart)
-            {
-                SeekCore(_fileHandle, oldPos, SeekOrigin.Begin);
-                throw new IOException(SR.IO_SeekAppendOverwrite);
-            }
-
-            // We now must update the read buffer.  We can in some cases simply
-            // update _readPos within the buffer, copy around the buffer so our
-            // Position property is still correct, and avoid having to do more
-            // reads from the disk.  Otherwise, discard the buffer's contents.
-            if (_readLength > 0)
-            {
-                // We can optimize the following condition:
-                // oldPos - _readPos <= pos < oldPos + _readLen - _readPos
-                if (oldPos == pos)
-                {
-                    if (_readPos > 0)
-                    {
-                        Buffer.BlockCopy(GetBuffer(), _readPos, GetBuffer(), 0, _readLength - _readPos);
-                        _readLength -= _readPos;
-                        _readPos = 0;
-                    }
-                    // If we still have buffered data, we must update the stream's
-                    // position so our Position property is correct.
-                    if (_readLength > 0)
-                        SeekCore(_fileHandle, _readLength, SeekOrigin.Current);
-                }
-                else if (oldPos - _readPos < pos && pos < oldPos + _readLength - _readPos)
-                {
-                    int diff = (int)(pos - oldPos);
-                    Buffer.BlockCopy(GetBuffer(), _readPos + diff, GetBuffer(), 0, _readLength - (_readPos + diff));
-                    _readLength -= (_readPos + diff);
-                    _readPos = 0;
-                    if (_readLength > 0)
-                        SeekCore(_fileHandle, _readLength, SeekOrigin.Current);
-                }
-                else
-                {
-                    // Lose the read buffer.
-                    _readPos = 0;
-                    _readLength = 0;
-                }
-                Debug.Assert(_readLength >= 0 && _readPos <= _readLength, "_readLen should be nonnegative, and _readPos should be less than or equal _readLen");
-                Debug.Assert(pos == Position, "Seek optimization: pos != Position!  Buffer math was mangled.");
-            }
-            return pos;
-        }
-
-        // This doesn't do argument checking.  Necessary for SetLength, which must
-        // set the file pointer beyond the end of the file. This will update the
-        // internal position
-        protected override long SeekCore(SafeFileHandle fileHandle, long offset, SeekOrigin origin, bool closeInvalidHandle = false)
-        {
-            Debug.Assert(!fileHandle.IsClosed && _canSeek, "!fileHandle.IsClosed && _canSeek");
-            Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End, "origin >= SeekOrigin.Begin && origin <= SeekOrigin.End");
-
-            if (!Interop.Kernel32.SetFilePointerEx(fileHandle, offset, out long ret, (uint)origin))
-            {
-                if (closeInvalidHandle)
-                {
-                    throw Win32Marshal.GetExceptionForWin32Error(GetLastWin32ErrorAndDisposeHandleIfInvalid(), _path);
-                }
-                else
-                {
-                    throw Win32Marshal.GetExceptionForLastWin32Error(_path);
-                }
-            }
-
-            _filePosition = ret;
-            return ret;
-        }
-
-        protected override void OnBufferAllocated()
-        {
-            Debug.Assert(_buffer != null);
-            Debug.Assert(_preallocatedOverlapped == null);
-
-            if (_useAsyncIO)
-                _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, _buffer);
-        }
-
-        protected override void WriteSpan(ReadOnlySpan<byte> source)
-        {
-            Debug.Assert(!_useAsyncIO, "Must only be used when in synchronous mode");
-
-            if (_writePos == 0)
-            {
-                // Ensure we can write to the stream, and ready buffer for writing.
-                if (!CanWrite) throw Error.GetWriteNotSupported();
-                if (_readPos < _readLength) FlushReadBuffer();
-                _readPos = 0;
-                _readLength = 0;
-            }
-
-            // If our buffer has data in it, copy data from the user's array into
-            // the buffer, and if we can fit it all there, return.  Otherwise, write
-            // the buffer to disk and copy any remaining data into our buffer.
-            // The assumption here is memcpy is cheaper than disk (or net) IO.
-            // (10 milliseconds to disk vs. ~20-30 microseconds for a 4K memcpy)
-            // So the extra copying will reduce the total number of writes, in
-            // non-pathological cases (i.e. write 1 byte, then write for the buffer
-            // size repeatedly)
-            if (_writePos > 0)
-            {
-                int numBytes = _bufferLength - _writePos;   // space left in buffer
-                if (numBytes > 0)
-                {
-                    if (numBytes >= source.Length)
-                    {
-                        source.CopyTo(GetBuffer().AsSpan(_writePos));
-                        _writePos += source.Length;
-                        return;
-                    }
-                    else
-                    {
-                        source.Slice(0, numBytes).CopyTo(GetBuffer().AsSpan(_writePos));
-                        _writePos += numBytes;
-                        source = source.Slice(numBytes);
-                    }
-                }
-                // Reset our buffer.  We essentially want to call FlushWrite
-                // without calling Flush on the underlying Stream.
-
-                WriteCore(new ReadOnlySpan<byte>(GetBuffer(), 0, _writePos));
-                _writePos = 0;
-            }
-
-            // If the buffer would slow writes down, avoid buffer completely.
-            if (source.Length >= _bufferLength)
-            {
-                Debug.Assert(_writePos == 0, "FileStream cannot have buffered data to write here!  Your stream will be corrupted.");
-                WriteCore(source);
-                return;
-            }
-            else if (source.Length == 0)
-            {
-                return;  // Don't allocate a buffer then call memcpy for 0 bytes.
-            }
-
-            // Copy remaining bytes into buffer, to write at a later date.
-            source.CopyTo(GetBuffer().AsSpan(_writePos));
-            _writePos = source.Length;
-            return;
-        }
-
-        private unsafe void WriteCore(ReadOnlySpan<byte> source)
-        {
-            Debug.Assert(!_useAsyncIO);
-            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
-            Debug.Assert(CanWrite, "_parent.CanWrite");
-            Debug.Assert(_readPos == _readLength, "_readPos == _readLen");
-
-            // Make sure we are writing to the position that we think we are
-            VerifyOSHandlePosition();
-
-            int r = WriteFileNative(_fileHandle, source, null, out int errorCode);
-
-            if (r == -1)
-            {
-                // For pipes, ERROR_NO_DATA is not an error, but the pipe is closing.
-                if (errorCode == ERROR_NO_DATA)
-                {
-                    r = 0;
-                }
-                else
-                {
-                    // ERROR_INVALID_PARAMETER may be returned for writes
-                    // where the position is too large or for synchronous writes
-                    // to a handle opened asynchronously.
-                    if (errorCode == ERROR_INVALID_PARAMETER)
-                        throw new IOException(SR.IO_FileTooLongOrHandleNotSync);
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                }
-            }
-            Debug.Assert(r >= 0, "FileStream's WriteCore is likely broken.");
-            _filePosition += r;
-            return;
-        }
-
-        protected override Task<int>? ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken, out int synchronousResult)
-        {
-            Debug.Assert(_useAsyncIO);
-            if (!CanRead) throw Error.GetReadNotSupported();
-
-            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
-
-            if (_isPipe)
-            {
-                // Pipes are tricky, at least when you have 2 different pipes
-                // that you want to use simultaneously.  When redirecting stdout
-                // & stderr with the Process class, it's easy to deadlock your
-                // parent & child processes when doing writes 4K at a time.  The
-                // OS appears to use a 4K buffer internally.  If you write to a
-                // pipe that is full, you will block until someone read from
-                // that pipe.  If you try reading from an empty pipe and
-                // Win32FileStream's ReadAsync blocks waiting for data to fill it's
-                // internal buffer, you will be blocked.  In a case where a child
-                // process writes to stdout & stderr while a parent process tries
-                // reading from both, you can easily get into a deadlock here.
-                // To avoid this deadlock, don't buffer when doing async IO on
-                // pipes.  But don't completely ignore buffered data either.
-                if (_readPos < _readLength)
-                {
-                    int n = Math.Min(_readLength - _readPos, destination.Length);
-                    new Span<byte>(GetBuffer(), _readPos, n).CopyTo(destination.Span);
-                    _readPos += n;
-                    synchronousResult = n;
-                    return null;
-                }
-                else
-                {
-                    Debug.Assert(_writePos == 0, "Win32FileStream must not have buffered write data here!  Pipes should be unidirectional.");
-                    synchronousResult = 0;
-                    return ReadNativeAsync(destination, 0, cancellationToken);
-                }
-            }
-
-            Debug.Assert(!_isPipe, "Should not be a pipe.");
-
-            // Handle buffering.
-            if (_writePos > 0) FlushWriteBuffer();
-            if (_readPos == _readLength)
-            {
-                // I can't see how to handle buffering of async requests when
-                // filling the buffer asynchronously, without a lot of complexity.
-                // The problems I see are issuing an async read, we do an async
-                // read to fill the buffer, then someone issues another read
-                // (either synchronously or asynchronously) before the first one
-                // returns.  This would involve some sort of complex buffer locking
-                // that we probably don't want to get into, at least not in V1.
-                // If we did a sync read to fill the buffer, we could avoid the
-                // problem, and any async read less than 64K gets turned into a
-                // synchronous read by NT anyways...       --
-
-                if (destination.Length < _bufferLength)
-                {
-                    Task<int> readTask = ReadNativeAsync(new Memory<byte>(GetBuffer()), 0, cancellationToken);
-                    _readLength = readTask.GetAwaiter().GetResult();
-                    int n = Math.Min(_readLength, destination.Length);
-                    new Span<byte>(GetBuffer(), 0, n).CopyTo(destination.Span);
-                    _readPos = n;
-
-                    synchronousResult = n;
-                    return null;
-                }
-                else
-                {
-                    // Here we're making our position pointer inconsistent
-                    // with our read buffer.  Throw away the read buffer's contents.
-                    _readPos = 0;
-                    _readLength = 0;
-                    synchronousResult = 0;
-                    return ReadNativeAsync(destination, 0, cancellationToken);
-                }
-            }
-            else
-            {
-                int n = Math.Min(_readLength - _readPos, destination.Length);
-                new Span<byte>(GetBuffer(), _readPos, n).CopyTo(destination.Span);
-                _readPos += n;
-
-                if (n == destination.Length)
-                {
-                    // Return a completed task
-                    synchronousResult = n;
-                    return null;
-                }
-                else
-                {
-                    // For streams with no clear EOF like serial ports or pipes
-                    // we cannot read more data without causing an app to block
-                    // incorrectly.  Pipes don't go down this path
-                    // though.  This code needs to be fixed.
-                    // Throw away read buffer.
-                    _readPos = 0;
-                    _readLength = 0;
-                    synchronousResult = 0;
-                    return ReadNativeAsync(destination.Slice(n), n, cancellationToken);
+                    throw new IOException(SR.IO_FileStreamHandlePosition);
                 }
             }
         }
 
-        private unsafe Task<int> ReadNativeAsync(Memory<byte> destination, int numBufferedBytesRead, CancellationToken cancellationToken)
-        {
-            AssertCanRead();
-            Debug.Assert(_useAsyncIO, "ReadNativeAsync doesn't work on synchronous file streams!");
-
-            // Create and store async stream class library specific data in the async result
-            FileStreamCompletionSource completionSource = FileStreamCompletionSource.Create(this, numBufferedBytesRead, destination);
-            NativeOverlapped* intOverlapped = completionSource.Overlapped;
-
-            // Calculate position in the file we should be at after the read is done
-            if (CanSeek)
-            {
-                long len = Length;
-
-                // Make sure we are reading from the position that we think we are
-                VerifyOSHandlePosition();
-
-                if (_filePosition + destination.Length > len)
-                {
-                    if (_filePosition <= len)
-                    {
-                        destination = destination.Slice(0, (int)(len - _filePosition));
-                    }
-                    else
-                    {
-                        destination = default;
-                    }
-                }
-
-                // Now set the position to read from in the NativeOverlapped struct
-                // For pipes, we should leave the offset fields set to 0.
-                intOverlapped->OffsetLow = unchecked((int)_filePosition);
-                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
-
-                // When using overlapped IO, the OS is not supposed to
-                // touch the file pointer location at all.  We will adjust it
-                // ourselves. This isn't threadsafe.
-
-                // WriteFile should not update the file pointer when writing
-                // in overlapped mode, according to MSDN.  But it does update
-                // the file pointer when writing to a UNC path!
-                // So changed the code below to seek to an absolute
-                // location, not a relative one.  ReadFile seems consistent though.
-                SeekCore(_fileHandle, destination.Length, SeekOrigin.Current);
-            }
-
-            // queue an async ReadFile operation and pass in a packed overlapped
-            int r = ReadFileNative(_fileHandle, destination.Span, intOverlapped, out int errorCode);
-
-            // ReadFile, the OS version, will return 0 on failure.  But
-            // my ReadFileNative wrapper returns -1.  My wrapper will return
-            // the following:
-            // On error, r==-1.
-            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
-            // on async requests that completed sequentially, r==0
-            // You will NEVER RELIABLY be able to get the number of bytes
-            // read back from this call when using overlapped structures!  You must
-            // not pass in a non-null lpNumBytesRead to ReadFile when using
-            // overlapped structures!  This is by design NT behavior.
-            if (r == -1)
-            {
-                // For pipes, when they hit EOF, they will come here.
-                if (errorCode == ERROR_BROKEN_PIPE)
-                {
-                    // Not an error, but EOF.  AsyncFSCallback will NOT be
-                    // called.  Call the user callback here.
-
-                    // We clear the overlapped status bit for this special case.
-                    // Failure to do so looks like we are freeing a pending overlapped later.
-                    intOverlapped->InternalLow = IntPtr.Zero;
-                    completionSource.SetCompletedSynchronously(0);
-                }
-                else if (errorCode != ERROR_IO_PENDING)
-                {
-                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
-                    {
-                        SeekCore(_fileHandle, 0, SeekOrigin.Current);
-                    }
-
-                    completionSource.ReleaseNativeResource();
-
-                    if (errorCode == ERROR_HANDLE_EOF)
-                    {
-                        throw Error.GetEndOfFile();
-                    }
-                    else
-                    {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                    }
-                }
-                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
-                {
-                    // Only once the IO is pending do we register for cancellation
-                    completionSource.RegisterForCancellation(cancellationToken);
-                }
-            }
-            else
-            {
-                // Due to a workaround for a race condition in NT's ReadFile &
-                // WriteFile routines, we will always be returning 0 from ReadFileNative
-                // when we do async IO instead of the number of bytes read,
-                // irregardless of whether the operation completed
-                // synchronously or asynchronously.  We absolutely must not
-                // set asyncResult._numBytes here, since will never have correct
-                // results.
-            }
-
-            return completionSource.Task;
-        }
-
-        protected override ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
-        {
-            Debug.Assert(_useAsyncIO);
-            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
-            Debug.Assert(!_isPipe || (_readPos == 0 && _readLength == 0), "Win32FileStream must not have buffered data here!  Pipes should be unidirectional.");
-
-            if (!CanWrite) throw Error.GetWriteNotSupported();
-
-            bool writeDataStoredInBuffer = false;
-            if (!_isPipe) // avoid async buffering with pipes, as doing so can lead to deadlocks (see comments in ReadInternalAsyncCore)
-            {
-                // Ensure the buffer is clear for writing
-                if (_writePos == 0)
-                {
-                    if (_readPos < _readLength)
-                    {
-                        FlushReadBuffer();
-                    }
-                    _readPos = 0;
-                    _readLength = 0;
-                }
-
-                // Determine how much space remains in the buffer
-                int remainingBuffer = _bufferLength - _writePos;
-                Debug.Assert(remainingBuffer >= 0);
-
-                // Simple/common case:
-                // - The write is smaller than our buffer, such that it's worth considering buffering it.
-                // - There's no active flush operation, such that we don't have to worry about the existing buffer being in use.
-                // - And the data we're trying to write fits in the buffer, meaning it wasn't already filled by previous writes.
-                // In that case, just store it in the buffer.
-                if (source.Length < _bufferLength && !HasActiveBufferOperation && source.Length <= remainingBuffer)
-                {
-                    source.Span.CopyTo(new Span<byte>(GetBuffer(), _writePos, source.Length));
-                    _writePos += source.Length;
-                    writeDataStoredInBuffer = true;
-
-                    // There is one special-but-common case, common because devs often use
-                    // byte[] sizes that are powers of 2 and thus fit nicely into our buffer, which is
-                    // also a power of 2. If after our write the buffer still has remaining space,
-                    // then we're done and can return a completed task now.  But if we filled the buffer
-                    // completely, we want to do the asynchronous flush/write as part of this operation
-                    // rather than waiting until the next write that fills the buffer.
-                    if (source.Length != remainingBuffer)
-                        return default;
-
-                    Debug.Assert(_writePos == _bufferLength);
-                }
-            }
-
-            // At this point, at least one of the following is true:
-            // 1. There was an active flush operation (it could have completed by now, though).
-            // 2. The data doesn't fit in the remaining buffer (or it's a pipe and we chose not to try).
-            // 3. We wrote all of the data to the buffer, filling it.
-            //
-            // If there's an active operation, we can't touch the current buffer because it's in use.
-            // That gives us a choice: we can either allocate a new buffer, or we can skip the buffer
-            // entirely (even if the data would otherwise fit in it).  For now, for simplicity, we do
-            // the latter; it could also have performance wins due to OS-level optimizations, and we could
-            // potentially add support for PreAllocatedOverlapped due to having a single buffer. (We can
-            // switch to allocating a new buffer, potentially experimenting with buffer pooling, should
-            // performance data suggest it's appropriate.)
-            //
-            // If the data doesn't fit in the remaining buffer, it could be because it's so large
-            // it's greater than the entire buffer size, in which case we'd always skip the buffer,
-            // or it could be because there's more data than just the space remaining.  For the latter
-            // case, we need to issue an asynchronous write to flush that data, which then turns this into
-            // the first case above with an active operation.
-            //
-            // If we already stored the data, then we have nothing additional to write beyond what
-            // we need to flush.
-            //
-            // In any of these cases, we have the same outcome:
-            // - If there's data in the buffer, flush it by writing it out asynchronously.
-            // - Then, if there's any data to be written, issue a write for it concurrently.
-            // We return a Task that represents one or both.
-
-            // Flush the buffer asynchronously if there's anything to flush
-            Task? flushTask = null;
-            if (_writePos > 0)
-            {
-                flushTask = FlushWriteAsync(cancellationToken);
-
-                // If we already copied all of the data into the buffer,
-                // simply return the flush task here.  Same goes for if the task has
-                // already completed and was unsuccessful.
-                if (writeDataStoredInBuffer ||
-                    flushTask.IsFaulted ||
-                    flushTask.IsCanceled)
-                {
-                    return new ValueTask(flushTask);
-                }
-            }
-
-            Debug.Assert(!writeDataStoredInBuffer);
-            Debug.Assert(_writePos == 0);
-
-            // Finally, issue the write asynchronously, and return a Task that logically
-            // represents the write operation, including any flushing done.
-            Task writeTask = WriteAsyncInternalCore(source, cancellationToken);
-            return new ValueTask(
-                (flushTask == null || flushTask.Status == TaskStatus.RanToCompletion) ? writeTask :
-                (writeTask.Status == TaskStatus.RanToCompletion) ? flushTask :
-                Task.WhenAll(flushTask, writeTask));
-        }
-
-        private unsafe Task WriteAsyncInternalCore(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
-        {
-            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
-            Debug.Assert(CanWrite, "_parent.CanWrite");
-            Debug.Assert(_readPos == _readLength, "_readPos == _readLen");
-            Debug.Assert(_useAsyncIO, "WriteInternalCoreAsync doesn't work on synchronous file streams!");
-
-            // Create and store async stream class library specific data in the async result
-            FileStreamCompletionSource completionSource = FileStreamCompletionSource.Create(this, 0, source);
-            NativeOverlapped* intOverlapped = completionSource.Overlapped;
-
-            if (CanSeek)
-            {
-                // Make sure we set the length of the file appropriately.
-                long len = Length;
-
-                // Make sure we are writing to the position that we think we are
-                VerifyOSHandlePosition();
-
-                if (_filePosition + source.Length > len)
-                {
-                    SetLengthCore(_filePosition + source.Length);
-                }
-
-                // Now set the position to read from in the NativeOverlapped struct
-                // For pipes, we should leave the offset fields set to 0.
-                intOverlapped->OffsetLow = (int)_filePosition;
-                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
-
-                // When using overlapped IO, the OS is not supposed to
-                // touch the file pointer location at all.  We will adjust it
-                // ourselves.  This isn't threadsafe.
-                SeekCore(_fileHandle, source.Length, SeekOrigin.Current);
-            }
-
-            // queue an async WriteFile operation and pass in a packed overlapped
-            int r = WriteFileNative(_fileHandle, source.Span, intOverlapped, out int errorCode);
-
-            // WriteFile, the OS version, will return 0 on failure.  But
-            // my WriteFileNative wrapper returns -1.  My wrapper will return
-            // the following:
-            // On error, r==-1.
-            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
-            // On async requests that completed sequentially, r==0
-            // You will NEVER RELIABLY be able to get the number of bytes
-            // written back from this call when using overlapped IO!  You must
-            // not pass in a non-null lpNumBytesWritten to WriteFile when using
-            // overlapped structures!  This is ByDesign NT behavior.
-            if (r == -1)
-            {
-                // For pipes, when they are closed on the other side, they will come here.
-                if (errorCode == ERROR_NO_DATA)
-                {
-                    // Not an error, but EOF. AsyncFSCallback will NOT be called.
-                    // Completing TCS and return cached task allowing the GC to collect TCS.
-                    completionSource.SetCompletedSynchronously(0);
-                    return Task.CompletedTask;
-                }
-                else if (errorCode != ERROR_IO_PENDING)
-                {
-                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
-                    {
-                        SeekCore(_fileHandle, 0, SeekOrigin.Current);
-                    }
-
-                    completionSource.ReleaseNativeResource();
-
-                    if (errorCode == ERROR_HANDLE_EOF)
-                    {
-                        throw Error.GetEndOfFile();
-                    }
-                    else
-                    {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                    }
-                }
-                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
-                {
-                    // Only once the IO is pending do we register for cancellation
-                    completionSource.RegisterForCancellation(cancellationToken);
-                }
-            }
-            else
-            {
-                // Due to a workaround for a race condition in NT's ReadFile &
-                // WriteFile routines, we will always be returning 0 from WriteFileNative
-                // when we do async IO instead of the number of bytes written,
-                // irregardless of whether the operation completed
-                // synchronously or asynchronously.  We absolutely must not
-                // set asyncResult._numBytes here, since will never have correct
-                // results.
-            }
-
-            return completionSource.Task;
-        }
-
-        // Error codes (not HRESULTS), from winerror.h
-        internal const int ERROR_BROKEN_PIPE = 109;
-        internal const int ERROR_NO_DATA = 232;
-        private const int ERROR_HANDLE_EOF = 38;
-        private const int ERROR_INVALID_PARAMETER = 87;
-        private const int ERROR_IO_PENDING = 997;
-
-        // __ConsoleStream also uses this code.
-        private unsafe int ReadFileNative(SafeFileHandle handle, Span<byte> bytes, NativeOverlapped* overlapped, out int errorCode)
-        {
-            Debug.Assert(handle != null, "handle != null");
-            Debug.Assert((_useAsyncIO && overlapped != null) || (!_useAsyncIO && overlapped == null), "Async IO and overlapped parameters inconsistent in call to ReadFileNative.");
-
-            int r;
-            int numBytesRead = 0;
-
-            fixed (byte* p = &MemoryMarshal.GetReference(bytes))
-            {
-                r = _useAsyncIO ?
-                    Interop.Kernel32.ReadFile(handle, p, bytes.Length, IntPtr.Zero, overlapped) :
-                    Interop.Kernel32.ReadFile(handle, p, bytes.Length, out numBytesRead, IntPtr.Zero);
-            }
-
-            if (r == 0)
-            {
-                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
-                return -1;
-            }
-            else
-            {
-                errorCode = 0;
-                return numBytesRead;
-            }
-        }
-
-        private unsafe int WriteFileNative(SafeFileHandle handle, ReadOnlySpan<byte> buffer, NativeOverlapped* overlapped, out int errorCode)
-        {
-            Debug.Assert(handle != null, "handle != null");
-            Debug.Assert((_useAsyncIO && overlapped != null) || (!_useAsyncIO && overlapped == null), "Async IO and overlapped parameters inconsistent in call to WriteFileNative.");
-
-            int numBytesWritten = 0;
-            int r;
-
-            fixed (byte* p = &MemoryMarshal.GetReference(buffer))
-            {
-                r = _useAsyncIO ?
-                    Interop.Kernel32.WriteFile(handle, p, buffer.Length, IntPtr.Zero, overlapped) :
-                    Interop.Kernel32.WriteFile(handle, p, buffer.Length, out numBytesWritten, IntPtr.Zero);
-            }
-
-            if (r == 0)
-            {
-                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
-                return -1;
-            }
-            else
-            {
-                errorCode = 0;
-                return numBytesWritten;
-            }
-        }
-
-        private int GetLastWin32ErrorAndDisposeHandleIfInvalid()
+        protected int GetLastWin32ErrorAndDisposeHandleIfInvalid()
         {
             int errorCode = Marshal.GetLastWin32Error();
 
@@ -1235,333 +446,56 @@ namespace System.IO
             return errorCode;
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        // __ConsoleStream also uses this code.
+        protected unsafe int ReadFileNative(SafeFileHandle handle, Span<byte> bytes, NativeOverlapped* overlapped, out int errorCode)
         {
-            // If we're in sync mode, just use the shared CopyToAsync implementation that does
-            // typical read/write looping.
-            if (!_useAsyncIO)
+            Debug.Assert(handle != null, "handle != null");
+
+            int r;
+            int numBytesRead = 0;
+
+            fixed (byte* p = &MemoryMarshal.GetReference(bytes))
             {
-                return base.CopyToAsync(destination, bufferSize, cancellationToken);
+                r = overlapped != null ?
+                    Interop.Kernel32.ReadFile(handle, p, bytes.Length, IntPtr.Zero, overlapped) :
+                    Interop.Kernel32.ReadFile(handle, p, bytes.Length, out numBytesRead, IntPtr.Zero);
             }
 
-            ValidateCopyToArguments(destination, bufferSize);
-
-            // Fail if the file was closed
-            if (_fileHandle.IsClosed)
+            if (r == 0)
             {
-                throw Error.GetFileNotOpen();
+                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                return -1;
             }
-            if (!CanRead)
+            else
             {
-                throw Error.GetReadNotSupported();
-            }
-
-            // Bail early for cancellation if cancellation has been requested
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            // Do the async copy, with differing implementations based on whether the FileStream was opened as async or sync
-            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
-            return AsyncModeCopyToAsync(destination, bufferSize, cancellationToken);
-        }
-
-        private async Task AsyncModeCopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
-        {
-            Debug.Assert(_useAsyncIO, "This implementation is for async mode only");
-            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
-            Debug.Assert(CanRead, "_parent.CanRead");
-
-            // Make sure any pending writes have been flushed before we do a read.
-            if (_writePos > 0)
-            {
-                await FlushWriteAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            // Typically CopyToAsync would be invoked as the only "read" on the stream, but it's possible some reading is
-            // done and then the CopyToAsync is issued.  For that case, see if we have any data available in the buffer.
-            if (GetBuffer() != null)
-            {
-                int bufferedBytes = _readLength - _readPos;
-                if (bufferedBytes > 0)
-                {
-                    await destination.WriteAsync(new ReadOnlyMemory<byte>(GetBuffer(), _readPos, bufferedBytes), cancellationToken).ConfigureAwait(false);
-                    _readPos = _readLength = 0;
-                }
-            }
-
-            // For efficiency, we avoid creating a new task and associated state for each asynchronous read.
-            // Instead, we create a single reusable awaitable object that will be triggered when an await completes
-            // and reset before going again.
-            var readAwaitable = new AsyncCopyToAwaitable(this);
-
-            // Make sure we are reading from the position that we think we are.
-            // Only set the position in the awaitable if we can seek (e.g. not for pipes).
-            bool canSeek = CanSeek;
-            if (canSeek)
-            {
-                VerifyOSHandlePosition();
-                readAwaitable._position = _filePosition;
-            }
-
-            // Get the buffer to use for the copy operation, as the base CopyToAsync does. We don't try to use
-            // _buffer here, even if it's not null, as concurrent operations are allowed, and another operation may
-            // actually be using the buffer already. Plus, it'll be rare for _buffer to be non-null, as typically
-            // CopyToAsync is used as the only operation performed on the stream, and the buffer is lazily initialized.
-            // Further, typically the CopyToAsync buffer size will be larger than that used by the FileStream, such that
-            // we'd likely be unable to use it anyway.  Instead, we rent the buffer from a pool.
-            byte[] copyBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-
-            // Allocate an Overlapped we can use repeatedly for all operations
-            var awaitableOverlapped = new PreAllocatedOverlapped(AsyncCopyToAwaitable.s_callback, readAwaitable, copyBuffer);
-            var cancellationReg = default(CancellationTokenRegistration);
-            try
-            {
-                // Register for cancellation.  We do this once for the whole copy operation, and just try to cancel
-                // whatever read operation may currently be in progress, if there is one.  It's possible the cancellation
-                // request could come in between operations, in which case we flag that with explicit calls to ThrowIfCancellationRequested
-                // in the read/write copy loop.
-                if (cancellationToken.CanBeCanceled)
-                {
-                    cancellationReg = cancellationToken.UnsafeRegister(static s =>
-                    {
-                        Debug.Assert(s is AsyncCopyToAwaitable);
-                        var innerAwaitable = (AsyncCopyToAwaitable)s;
-                        unsafe
-                        {
-                            lock (innerAwaitable.CancellationLock) // synchronize with cleanup of the overlapped
-                            {
-                                if (innerAwaitable._nativeOverlapped != null)
-                                {
-                                    // Try to cancel the I/O.  We ignore the return value, as cancellation is opportunistic and we
-                                    // don't want to fail the operation because we couldn't cancel it.
-                                    Interop.Kernel32.CancelIoEx(innerAwaitable._fileStream._fileHandle, innerAwaitable._nativeOverlapped);
-                                }
-                            }
-                        }
-                    }, readAwaitable);
-                }
-
-                // Repeatedly read from this FileStream and write the results to the destination stream.
-                while (true)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    readAwaitable.ResetForNextOperation();
-
-                    try
-                    {
-                        bool synchronousSuccess;
-                        int errorCode;
-                        unsafe
-                        {
-                            // Allocate a native overlapped for our reusable overlapped, and set position to read based on the next
-                            // desired address stored in the awaitable.  (This position may be 0, if either we're at the beginning or
-                            // if the stream isn't seekable.)
-                            readAwaitable._nativeOverlapped = _fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(awaitableOverlapped);
-                            if (canSeek)
-                            {
-                                readAwaitable._nativeOverlapped->OffsetLow = unchecked((int)readAwaitable._position);
-                                readAwaitable._nativeOverlapped->OffsetHigh = (int)(readAwaitable._position >> 32);
-                            }
-
-                            // Kick off the read.
-                            synchronousSuccess = ReadFileNative(_fileHandle, copyBuffer, readAwaitable._nativeOverlapped, out errorCode) >= 0;
-                        }
-
-                        // If the operation did not synchronously succeed, it either failed or initiated the asynchronous operation.
-                        if (!synchronousSuccess)
-                        {
-                            switch (errorCode)
-                            {
-                                case ERROR_IO_PENDING:
-                                    // Async operation in progress.
-                                    break;
-                                case ERROR_BROKEN_PIPE:
-                                case ERROR_HANDLE_EOF:
-                                    // We're at or past the end of the file, and the overlapped callback
-                                    // won't be raised in these cases. Mark it as completed so that the await
-                                    // below will see it as such.
-                                    readAwaitable.MarkCompleted();
-                                    break;
-                                default:
-                                    // Everything else is an error (and there won't be a callback).
-                                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                            }
-                        }
-
-                        // Wait for the async operation (which may or may not have already completed), then throw if it failed.
-                        await readAwaitable;
-                        switch (readAwaitable._errorCode)
-                        {
-                            case 0: // success
-                                break;
-                            case ERROR_BROKEN_PIPE: // logically success with 0 bytes read (write end of pipe closed)
-                            case ERROR_HANDLE_EOF:  // logically success with 0 bytes read (read at end of file)
-                                Debug.Assert(readAwaitable._numBytes == 0, $"Expected 0 bytes read, got {readAwaitable._numBytes}");
-                                break;
-                            case Interop.Errors.ERROR_OPERATION_ABORTED: // canceled
-                                throw new OperationCanceledException(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
-                            default: // error
-                                throw Win32Marshal.GetExceptionForWin32Error((int)readAwaitable._errorCode, _path);
-                        }
-
-                        // Successful operation.  If we got zero bytes, we're done: exit the read/write loop.
-                        int numBytesRead = (int)readAwaitable._numBytes;
-                        if (numBytesRead == 0)
-                        {
-                            break;
-                        }
-
-                        // Otherwise, update the read position for next time accordingly.
-                        if (canSeek)
-                        {
-                            readAwaitable._position += numBytesRead;
-                        }
-                    }
-                    finally
-                    {
-                        // Free the resources for this read operation
-                        unsafe
-                        {
-                            NativeOverlapped* overlapped;
-                            lock (readAwaitable.CancellationLock) // just an Exchange, but we need this to be synchronized with cancellation, so using the same lock
-                            {
-                                overlapped = readAwaitable._nativeOverlapped;
-                                readAwaitable._nativeOverlapped = null;
-                            }
-                            if (overlapped != null)
-                            {
-                                _fileHandle.ThreadPoolBinding!.FreeNativeOverlapped(overlapped);
-                            }
-                        }
-                    }
-
-                    // Write out the read data.
-                    await destination.WriteAsync(new ReadOnlyMemory<byte>(copyBuffer, 0, (int)readAwaitable._numBytes), cancellationToken).ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                // Cleanup from the whole copy operation
-                cancellationReg.Dispose();
-                awaitableOverlapped.Dispose();
-
-                ArrayPool<byte>.Shared.Return(copyBuffer);
-
-                // Make sure the stream's current position reflects where we ended up
-                if (!_fileHandle.IsClosed && CanSeek)
-                {
-                    SeekCore(_fileHandle, 0, SeekOrigin.End);
-                }
+                errorCode = 0;
+                return numBytesRead;
             }
         }
 
-        /// <summary>Used by CopyToAsync to enable awaiting the result of an overlapped I/O operation with minimal overhead.</summary>
-        private sealed unsafe class AsyncCopyToAwaitable : ICriticalNotifyCompletion
+        protected unsafe int WriteFileNative(SafeFileHandle handle, ReadOnlySpan<byte> buffer, NativeOverlapped* overlapped, out int errorCode)
         {
-            /// <summary>Sentinel object used to indicate that the I/O operation has completed before being awaited.</summary>
-            private static readonly Action s_sentinel = () => { };
-            /// <summary>Cached delegate to IOCallback.</summary>
-            internal static readonly IOCompletionCallback s_callback = IOCallback;
+            Debug.Assert(handle != null, "handle != null");
 
-            /// <summary>The FileStream that owns this instance.</summary>
-            internal readonly WindowsFileStreamStrategy _fileStream;
+            int numBytesWritten = 0;
+            int r;
 
-            /// <summary>Tracked position representing the next location from which to read.</summary>
-            internal long _position;
-            /// <summary>The current native overlapped pointer.  This changes for each operation.</summary>
-            internal NativeOverlapped* _nativeOverlapped;
-            /// <summary>
-            /// null if the operation is still in progress,
-            /// s_sentinel if the I/O operation completed before the await,
-            /// s_callback if it completed after the await yielded.
-            /// </summary>
-            internal Action? _continuation;
-            /// <summary>Last error code from completed operation.</summary>
-            internal uint _errorCode;
-            /// <summary>Last number of read bytes from completed operation.</summary>
-            internal uint _numBytes;
-
-            /// <summary>Lock object used to protect cancellation-related access to _nativeOverlapped.</summary>
-            internal object CancellationLock => this;
-
-            /// <summary>Initialize the awaitable.</summary>
-            internal AsyncCopyToAwaitable(WindowsFileStreamStrategy fileStream)
+            fixed (byte* p = &MemoryMarshal.GetReference(buffer))
             {
-                _fileStream = fileStream;
+                r = overlapped != null ?
+                    Interop.Kernel32.WriteFile(handle, p, buffer.Length, IntPtr.Zero, overlapped) :
+                    Interop.Kernel32.WriteFile(handle, p, buffer.Length, out numBytesWritten, IntPtr.Zero);
             }
 
-            /// <summary>Reset state to prepare for the next read operation.</summary>
-            internal void ResetForNextOperation()
+            if (r == 0)
             {
-                Debug.Assert(_position >= 0, $"Expected non-negative position, got {_position}");
-                _continuation = null;
-                _errorCode = 0;
-                _numBytes = 0;
+                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                return -1;
             }
-
-            /// <summary>Overlapped callback: store the results, then invoke the continuation delegate.</summary>
-            internal static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOVERLAP)
+            else
             {
-                var awaitable = (AsyncCopyToAwaitable?)ThreadPoolBoundHandle.GetNativeOverlappedState(pOVERLAP);
-                Debug.Assert(awaitable != null);
-
-                Debug.Assert(!ReferenceEquals(awaitable._continuation, s_sentinel), "Sentinel must not have already been set as the continuation");
-                awaitable._errorCode = errorCode;
-                awaitable._numBytes = numBytes;
-
-                (awaitable._continuation ?? Interlocked.CompareExchange(ref awaitable._continuation, s_sentinel, null))?.Invoke();
-            }
-
-            /// <summary>
-            /// Called when it's known that the I/O callback for an operation will not be invoked but we'll
-            /// still be awaiting the awaitable.
-            /// </summary>
-            internal void MarkCompleted()
-            {
-                Debug.Assert(_continuation == null, "Expected null continuation");
-                _continuation = s_sentinel;
-            }
-
-            public AsyncCopyToAwaitable GetAwaiter() => this;
-            public bool IsCompleted => ReferenceEquals(_continuation, s_sentinel);
-            public void GetResult() { }
-            public void OnCompleted(Action continuation) => UnsafeOnCompleted(continuation);
-            public void UnsafeOnCompleted(Action continuation)
-            {
-                if (ReferenceEquals(_continuation, s_sentinel) ||
-                    Interlocked.CompareExchange(ref _continuation, continuation, null) != null)
-                {
-                    Debug.Assert(ReferenceEquals(_continuation, s_sentinel), $"Expected continuation set to s_sentinel, got ${_continuation}");
-                    Task.Run(continuation);
-                }
-            }
-        }
-
-        internal override void Lock(long position, long length)
-        {
-            int positionLow = unchecked((int)(position));
-            int positionHigh = unchecked((int)(position >> 32));
-            int lengthLow = unchecked((int)(length));
-            int lengthHigh = unchecked((int)(length >> 32));
-
-            if (!Interop.Kernel32.LockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
-            {
-                throw Win32Marshal.GetExceptionForLastWin32Error(_path);
-            }
-        }
-
-        internal override void Unlock(long position, long length)
-        {
-            int positionLow = unchecked((int)(position));
-            int positionHigh = unchecked((int)(position >> 32));
-            int lengthLow = unchecked((int)(length));
-            int lengthHigh = unchecked((int)(length >> 32));
-
-            if (!Interop.Kernel32.UnlockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
-            {
-                throw Win32Marshal.GetExceptionForLastWin32Error(_path);
+                errorCode = 0;
+                return numBytesWritten;
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -920,8 +920,10 @@ namespace System.Threading
         {
             if (m_lockObjAndDisposed.Value)
             {
-                throw new ObjectDisposedException(null, SR.SemaphoreSlim_Disposed);
+                Throw();
             }
+
+            static void Throw() => throw new ObjectDisposedException(null, SR.SemaphoreSlim_Disposed);
         }
         #endregion
     }


### PR DESCRIPTION
@carlossanlop @Jozkee @stephentoub Please note that this PR is not even a draft, it's a PR in my fork. I've opened it as I want to get your opinion before I invest more time in it.

For the last couple of days I have been trying to wrap my head around:

* Win32 FileStream turns async reads into sync reads https://github.com/dotnet/runtime/issues/16341
* FileStream.FlushAsync ends up doing synchronous writes https://github.com/dotnet/runtime/issues/27643

@stephentoub has suggested [here](https://github.com/dotnet/runtime/issues/16341#issuecomment-293347286) how this could be solved.
To be honest with you I don't like this approach as in my opinion it would not be 100% thread-safe (it's OK, FileStream was never promised to be thread-safe) and it would make FileStream **even more complex**. 
It's definitely doable but if it's possible I would prefer to avoid making FileStream even more complex.

Stephen has also suggested using `BufferedStream` and removing all the buffering logic from the strategies themselves: https://github.com/dotnet/runtime/pull/47128#discussion_r560395799
I love the idea of removing the buffering logic from `FileStream`. And this is what I've tried in this PR (branch). It makes both `AsyncWindowsFileStreamStrategy` and `SyncWindowsFileStreamStrategy` super simple and very clean (no if checks, just tiny wrappers around OS calls, see the code below). `SyncWindowsFileStreamStrategy` is just 169 lines of code (half of it are comments)!!

Moreover, `BufferedStream` **solves the problem of doing sync method calls from async methods to handle the buffering**.

`BufferedStream` uses `SempahoreSlim` to achieve that:

https://github.com/dotnet/runtime/blob/16a9d5d6a2290a4f13fc4b42bf433588d481c39f/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs#L661-L663

This comes with a performance penalty but also with a breaking change.

Until now, it was possible to start multiple async reads|writes and await them later. By using `BufferedStream` that acquires a lock it's still possible, but the requests would not be executed in parallel and `FileStream.Position` would get updated **after the request would be finished**:

https://github.com/dotnet/runtime/blob/16a9d5d6a2290a4f13fc4b42bf433588d481c39f/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs#L1118-L1119

Test that fails after my changes:

https://github.com/dotnet/runtime/blob/16a9d5d6a2290a4f13fc4b42bf433588d481c39f/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs#L218-L229

If I remember correctly, we were initially OK with breaking that. But, if our users really want to perform async reads and writes in parallel, we could add offset-based methods to `FileStream` with a new mode (like `FileOptions.Overlapped`) that would not be using buffering at all (https://github.com/dotnet/runtime/issues/24847):

```diff
public partial class FileStream : System.IO.Stream
{
    public override int Read(byte[] buffer, int offset, int count)
    public override int Read(System.Span<byte> buffer)
+   public virtual int Read(System.Span<byte> buffer, long fileOffset)
    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
    public override ValueTask<int> ReadAsync(System.Memory<byte> buffer, CancellationToken cancellationToken)
+   public virtual ValueTask<int> ReadAsync(System.Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
    public override void Write(byte[] buffer, int offset, int count) { }
    public override void Write(ReadOnlySpan<byte> buffer) { }
+   public virtual void Write(ReadOnlySpan<byte> buffer, long fileOffset) { }    
    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+   public virtual ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
}
```

So on the one hand we would break 0.001% of our users that does that, but on the other, we would offer them a super-fast alternative (this is what most probably they wanted from the beginning).

Speaking of the performance penalty I've spent some time tunning `BufferedStream` perf and I was able to get to the point that there is no perf regression in most of the cases.

<details>

`\before\CoreRun.exe` is 6.0 without the concept of `FileStreamStrategy`:


|          Method |        Job |           Toolchain |  fileSize | userBufferSize |      options |          Median | Ratio |    Allocated |
|---------------- |----------- |-------------------- |---------- |--------------- |------------- |----------------:|------:|-------------:|
|            Read | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 |         None |        50.33 us |  0.99 |      4,384 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 |         None |        50.88 us |  1.00 |      4,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 |         None |       895.70 us |  1.00 |      4,384 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 |         None |       899.52 us |  1.00 |      4,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 |         None |        69.46 us |  1.00 |      5,128 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 |         None |        69.71 us |  1.00 |      4,848 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 |         None |       911.77 us |  0.98 |      4,472 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 |         None |       928.22 us |  1.00 |      4,840 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 | Asynchronous |        86.91 us |  1.25 |      5,304 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 | Asynchronous |        69.49 us |  1.00 |      4,713 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |            512 | Asynchronous |       985.40 us |  1.04 |      4,900 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |            512 | Asynchronous |       938.65 us |  1.00 |      4,693 B |
|                 |            |                     |           |                |              |                 |       |              |
|            Read | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 |         None |        49.06 us |  1.00 |        264 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 |         None |        49.19 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 |         None |       181.07 us |  1.00 |        264 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 |         None |       181.63 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 |         None |        66.77 us |  1.03 |        800 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 |         None |        64.61 us |  1.00 |        616 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 |         None |       182.16 us |  1.00 |        264 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 |         None |       181.49 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 | Asynchronous |        85.35 us |  1.03 |        968 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 | Asynchronous |        82.89 us |  1.00 |        760 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |           4096 | Asynchronous |       183.62 us |  1.00 |        320 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |           4096 | Asynchronous |       184.87 us |  1.00 |        200 B |
|                 |            |                     |           |                |              |                 |       |              |
|       OpenClose | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |        41.90 us |  1.01 |        264 B |
|       OpenClose | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |        41.68 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|      LockUnlock | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |        81.99 us |  1.04 |        264 B |
|      LockUnlock | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |        78.81 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|     SeekForward | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |       269.15 us |  1.04 |        264 B |
|     SeekForward | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |       258.58 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|    SeekBackward | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |     1,660.26 us |  1.01 |        265 B |
|    SeekBackward | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |     1,661.86 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|        ReadByte | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |        52.67 us |  0.96 |      4,384 B |
|        ReadByte | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |        54.19 us |  1.00 |      4,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|       WriteByte | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |       927.91 us |  1.01 |      4,385 B |
|       WriteByte | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |       931.51 us |  1.00 |      4,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Flush | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |     3,759.49 us |  1.00 |      4,386 B |
|           Flush | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |     3,802.99 us |  1.00 |      4,289 B |
|                 |            |                     |           |                |              |                 |       |              |
|      FlushAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |     7,357.75 us |  1.95 |    496,291 B |
|      FlushAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |     3,776.47 us |  1.00 |      4,306 B |
|                 |            |                     |           |                |              |                 |       |              |
|      CopyToFile | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |       986.10 us |  1.00 |      8,770 B |
|      CopyToFile | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |       998.14 us |  1.00 |      8,577 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? |         None |       985.46 us |  1.01 |      5,674 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? |         None |       983.22 us |  1.00 |      9,465 B |
|                 |            |                     |           |                |              |                 |       |              |
|       OpenClose | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |        43.52 us |  0.94 |        320 B |
|       OpenClose | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |        46.30 us |  1.00 |        200 B |
|                 |            |                     |           |                |              |                 |       |              |
|      LockUnlock | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |        86.53 us |  1.00 |        320 B |
|      LockUnlock | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |        88.61 us |  1.00 |        200 B |
|                 |            |                     |           |                |              |                 |       |              |
|     SeekForward | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |     2,391.24 us |  0.99 |        321 B |
|     SeekForward | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |     2,406.04 us |  1.00 |        201 B |
|                 |            |                     |           |                |              |                 |       |              |
|    SeekBackward | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |     4,811.03 us |  0.98 |        322 B |
|    SeekBackward | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |     4,843.99 us |  1.00 |        201 B |
|                 |            |                     |           |                |              |                 |       |              |
|        ReadByte | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |        71.92 us |  0.93 |      4,760 B |
|        ReadByte | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |        76.48 us |  1.00 |      4,641 B |
|                 |            |                     |           |                |              |                 |       |              |
|       WriteByte | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |     1,004.14 us |  1.04 |      4,805 B |
|       WriteByte | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |       966.91 us |  1.00 |      4,670 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Flush | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |    29,860.54 us |  1.68 |    152,195 B |
|           Flush | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |    17,744.32 us |  1.00 |    152,063 B |
|                 |            |                     |           |                |              |                 |       |              |
|      FlushAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |    35,450.52 us |  2.05 |    529,224 B |
|      FlushAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |    17,602.27 us |  1.00 |    152,279 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe |      1024 |              ? | Asynchronous |     1,095.60 us |  1.13 |      6,122 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe |      1024 |              ? | Asynchronous |     1,060.03 us |  1.00 |      9,860 B |
|                 |            |                     |           |                |              |                 |       |              |
|            Read | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 |         None |       711.89 us |  1.01 |      4,384 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 |         None |       709.69 us |  1.00 |      4,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 |         None |     6,203.04 us |  1.00 |      4,387 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 |         None |     6,442.30 us |  1.00 |      4,289 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 |         None |     1,628.45 us |  0.46 |     86,729 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 |         None |     3,509.77 us |  1.00 |    234,002 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 |         None |     8,688.55 us |  0.85 |     78,534 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 |         None |    10,451.96 us |  1.00 |    233,995 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 | Asynchronous |     4,675.79 us |  1.18 |     95,063 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 | Asynchronous |     3,979.44 us |  1.00 |     41,577 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |            512 | Asynchronous |    17,736.84 us |  1.63 |     86,874 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |            512 | Asynchronous |    10,844.67 us |  1.00 |     41,603 B |
|                 |            |                     |           |                |              |                 |       |              |
|            Read | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 |         None |       671.12 us |  1.04 |        264 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 |         None |       637.65 us |  1.00 |        168 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 |         None |     6,096.33 us |  1.04 |        267 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 |         None |     5,900.05 us |  1.00 |        169 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 |         None |     1,017.60 us |  1.03 |     29,361 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 |         None |       984.37 us |  1.00 |     29,176 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 |         None |     6,860.73 us |  1.04 |     29,356 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 |         None |     6,772.76 us |  1.00 |     29,169 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 | Asynchronous |     4,645.51 us |  1.03 |     80,530 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 | Asynchronous |     4,581.12 us |  1.00 |     80,337 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |           4096 | Asynchronous |    16,463.98 us |  1.02 |     80,530 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |           4096 | Asynchronous |    16,369.54 us |  1.00 |     80,314 B |
|                 |            |                     |           |                |              |                 |       |              |
|      CopyToFile | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |              ? |         None |     4,998.09 us |  1.05 |        537 B |
|      CopyToFile | Job-TPLJRT | \before\CoreRun.exe |   1048576 |              ? |         None |     4,865.97 us |  1.00 |        369 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |              ? |         None |     5,116.65 us |  1.00 |      3,327 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |              ? |         None |     5,161.07 us |  1.00 |      2,799 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe |   1048576 |              ? | Asynchronous |     5,707.27 us |  1.05 |      4,191 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe |   1048576 |              ? | Asynchronous |     5,626.98 us |  1.00 |      7,919 B |
|                 |            |                     |           |                |              |                 |       |              |
|            Read | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 |         None |    87,366.66 us |  1.00 |      4,420 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 |         None |    86,611.01 us |  1.00 |      4,304 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 |         None |   317,741.70 us |  1.08 |      4,528 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 |         None |   310,749.10 us |  1.00 |      4,352 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 |         None |   181,296.90 us |  0.49 |  8,196,952 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 |         None |   365,479.80 us |  1.00 | 22,942,288 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 |         None |   452,437.90 us |  0.69 |  7,377,784 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 |         None |   676,302.20 us |  1.00 | 22,942,320 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 | Asynchronous |   478,134.45 us |  1.17 |  9,016,088 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 | Asynchronous |   408,372.10 us |  1.00 |  3,692,312 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |            512 | Asynchronous | 1,663,906.70 us |  2.23 |  8,197,088 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |            512 | Asynchronous |   725,969.00 us |  1.00 |  3,691,952 B |
|                 |            |                     |           |                |              |                 |       |              |
|            Read | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 |         None |    78,886.50 us |  0.99 |        300 B |
|            Read | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 |         None |    81,857.69 us |  1.00 |        184 B |
|                 |            |                     |           |                |              |                 |       |              |
|           Write | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 |         None |   308,371.30 us |  1.09 |        408 B |
|           Write | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 |         None |   309,997.80 us |  1.00 |        232 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 |         None |   127,960.25 us |  0.99 |  2,868,032 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 |         None |   128,430.30 us |  1.00 |  2,867,736 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 |         None |   381,012.20 us |  1.09 |  2,868,064 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 |         None |   375,533.40 us |  1.00 |  2,867,760 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 | Asynchronous |   475,784.50 us |  0.99 |  7,988,000 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 | Asynchronous |   479,559.25 us |  1.00 |  7,987,712 B |
|                 |            |                     |           |                |              |                 |       |              |
|      WriteAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |           4096 | Asynchronous | 1,765,383.40 us |  0.98 |  7,987,992 B |
|      WriteAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |           4096 | Asynchronous | 1,784,226.70 us |  1.00 |  7,987,704 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |          16384 |         None |    53,870.68 us |  1.09 |    717,524 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |          16384 |         None |    49,269.25 us |  1.00 |    717,312 B |
|                 |            |                     |           |                |              |                 |       |              |
|       ReadAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |          16384 | Asynchronous |   140,858.83 us |  1.00 |  1,997,528 B |
|       ReadAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |          16384 | Asynchronous |   140,296.58 us |  1.00 |  1,997,280 B |
|                 |            |                     |           |                |              |                 |       |              |
|      CopyToFile | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |              ? |         None |    77,402.65 us |  1.02 |        636 B |
|      CopyToFile | Job-TPLJRT | \before\CoreRun.exe | 104857600 |              ? |         None |    77,272.05 us |  1.00 |        424 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |              ? |         None |    84,002.55 us |  1.01 |    180,908 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |              ? |         None |    83,337.45 us |  1.00 |    180,360 B |
|                 |            |                     |           |                |              |                 |       |              |
| CopyToFileAsync | Job-RQDFGV |  \after\CoreRun.exe | 104857600 |              ? | Asynchronous |   161,694.55 us |  1.06 |    251,640 B |
| CopyToFileAsync | Job-TPLJRT | \before\CoreRun.exe | 104857600 |              ? | Asynchronous |   160,787.30 us |  1.00 |    255,624 B |


</details>


But for some cases, `ReadAsync` and `WriteAsync` get a non-trivial hit. I've optimized mostly the `ReadAsync` path (did not spend too much time on `WriteAsync` as it was more proof of concept) and the perf penalty comes mostly from:

* the fact that we perform async IO (previously populating the `_buffer` with data from the disk was always sync. There is very little we can do about it and this is kind of expected. It pops up as a regression in single-threaded microbenchmark but would definitely improve throughput in most real-life scenarios.
* the async machinery (extra allocs). According to my understanding, this could be addressed by using `IValueTaskSource` as suggested by @stephentoub. And the fact that we would always have 1 active async read|Write in BufferedStream would make it even simpler?

We could minimize the overhead with `IValueTaskSource` and I am sure that by fixing https://github.com/dotnet/runtime/issues/16354 and https://github.com/dotnet/runtime/issues/25905 we could make `ReadAsync` and `WriteAsync` overall 20-60% faster than .NET  5.0 (depending on file and buffer size).

@stephentoub @carlossanlop @Jozkee Could you please take a brief look at my changes in `BufferedStream`, tests, and both Windows file strategies and let me know what do you think about using `BufferedStream`?

If we agree that this approach is acceptable, we could do the following:

* change https://github.com/dotnet/runtime/pull/47128 to just introduce the concept of `FileStreamStrategy` and move existing code to `LegacyFileStreamStrategy` (zero breaking changes)
* send a separate PR that would introduce `BufferedFileStreamStrategy` and `AsyncWindowsFileStreamStrategy` and `SyncWindowsFileStreamStrategy` (a more polished version of this PR). **Don't enable them by default yet** but make sure they are tested by the CI.
* In parallel:
  * apply `IValueTaskSource` suggestion
  * fix https://github.com/dotnet/runtime/issues/16354 and get a HUGE perf boost for `ReadAsync`
  * fix https://github.com/dotnet/runtime/issues/25905 and likely get a nice perf boost for `WriteAsync`
  * implement https://github.com/dotnet/runtime/issues/24847
* when done with all the above, **enable** the new Windows strategies by default and introduce all the changes at once in Preview X
* fix other problems in Preview X+1

cc @jeffhandley





